### PR TITLE
Ensure that Munge service is running

### DIFF
--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -82,6 +82,14 @@
     state: "{{ 'started' if openhpc_slurm_service_enabled | bool else 'stopped' }}"
   when: openhpc_slurm_service is not none
 
+# Munge state could be unchanged but the service is not running.
+# Handle that here.
+- name: Ensure Munge services are enabled and started
+  service:
+    name: munge
+    enabled: "{{ openhpc_slurm_service_enabled | bool }}"
+    state: "{{ 'started' if openhpc_slurm_service_enabled | bool else 'stopped' }}"
+
 # Install OpenHPC runtime
 - name: Ensure selected OpenHPC packages are installed
   yum:


### PR DESCRIPTION
It's easy to get into a situation where the Munge service is
enabled and configured but not actually running.  After the
handler that restarts the Munge service has been flushed,
ensure the Munge service is enabled and running.  This logic
ensures Munge is started (if it is not running) but does not
restart it if is running already.