### PR TITLE
Fix typo in README and note for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Role Variables
   * `num_nodes`: Nodes within the group are assumed to number `0:num_nodes-1`.
   * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`).
   
-  For each group (if used) or partition there must be an ansible inventory group `{cluster_name}_{group_name}`. The compute nodes in this group must have hostnames in the form `{cluster_name}-{group_name}-{0..num_nodes-1}` Note the inventory group uses "_" and the instances use "-".
+  For each group (if used) or partition there must be an ansible inventory group `{cluster_name}_{group_name}`. The compute nodes in this group must have hostnames in the form `{cluster_name}-{group_name}-{0..num_nodes-1}`. Note the inventory group uses "_" and the instances use "-".
   
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Role Variables
   * `num_nodes`: Nodes within the group are assumed to number `0:num_nodes-1`.
   * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`).
   
-  For each group (if used) or partition there must be an ansible inventory group `cluster_name-group_name`. The compute nodes in this group must have hostnames in the form `cluster_name-group_name-{0..num_nodes-1}`.
+  For each group (if used) or partition there must be an ansible inventory group `{cluster_name}_{group_name}`. The compute nodes in this group must have hostnames in the form `{cluster_name}-{group_name}-{0..num_nodes-1}` Note the inventory group uses "_" and the instances use "-".
   
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is


### PR DESCRIPTION
#29 unfortunately introduced a typo when trying to clarify the required inventory group names, saying it was `{cluster_name}-{group_name}` when actually it's `{cluster_name}_{group_name}`.

This PR fixes that, adds some `{}` to make it clearer what is variable and what's not, and adds a note specifically pointing out the difference because it's easy to miss.

Relevant lines in [slurm.conf](https://github.com/stackhpc/ansible-role-openhpc/blob/master/templates/slurm.conf.j2): inventory group @115, instance name at @108 and @129.