### PR TITLE
Molecule travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services:
   - docker
 before_install:
-  - sudo apt-get -qq updated
+  - sudo apt-get -qq update
 install:
   - python3 -m pip install ansible
   - python3 -m pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 ---
 language: python
-python: "2.7"
 
 # Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-    
+sudo: required
+services:
+  - docker
+before_install:
+  - sudo apt-get -qq updated
 install:
-  # Install ansible
-  - pip install ansible ansible-lint
-
+  - python3 -m pip install ansible
+  - python3 -m pip install ansible-lint
+  - python3 -m pip install molecule
+  - python3 -m pip install docker
+  
   # Check ansible version
   - ansible --version
 
@@ -33,6 +31,9 @@ script:
   
   # Test the custom filters
   - ansible-playbook tests/filter.yml -i tests/inventory -i tests/inventory-mock-groups
+
+  # Run molecule tests
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/filter_plugins/group_hosts.py
+++ b/filter_plugins/group_hosts.py
@@ -45,7 +45,7 @@ def _group_hosts(hosts):
             r.append(int(suffix))
         else:
             unmatchable.append(v)
-    return ['{}[{}]'.format(k, _group_numbers(v)) for k, v in results.iteritems()] + unmatchable
+    return ['{}[{}]'.format(k, _group_numbers(v)) for k, v in results.items()] + unmatchable
 
 def _group_numbers(numbers):
     units = []


### PR DESCRIPTION
Include molecule tests in travis.

**NB:** because this required moving to py3 there is a slight change to `filter_plugins.py`