### PR TITLE
Correct some linting failures

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
   
   # Run Ansible lint against the role
-  - ansible-lint tasks/main.yml  
+  - ansible-lint .
   
   # Test the custom filters
   - ansible-playbook tests/filter.yml -i tests/inventory -i tests/inventory-mock-groups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,17 @@
 - name: Gather package facts
   package_facts:
     manager: rpm
-- assert:
+
+- name: Check ohpc-release package is installed
+  assert:
     that: "'ohpc-release' in ansible_facts.packages"
     quiet: yes
     fail_msg: |
       "The OpenHPC distro package should be installed in the image.
        Please see http://openhpc.community/downloads/"
-- include_vars:
+
+- name: Include variables for OpenHPC version
+  include_vars:
     file: "ohpc-{{ ansible_facts.packages['ohpc-release'][0]['version'] }}"
 
 - include: control.yml


### PR DESCRIPTION
We are still getting a false positive for the role name:

```
(tox-new5) [will@juno ansible-role-openhpc]$ ansible-lint .
[106] Role name ansible-role-openhpc does not match ``^[a-z][a-z0-9_]+$`` pattern
tasks/drain.yml:1
---
```