### PR TITLE
Add configuration of ohcp-release and powertools into role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
   - ln -s $(pwd) ../stackhpc.openhpc
 
 env:
-  - SCENARIO=test1
+  - SCENARIO=test1 MOLECULE_IMAGE=centos:7
+  - SCENARIO=test1 MOLECULE_IMAGE=centos:8
   - SCENARIO=test1b
   - SCENARIO=test1c
   - SCENARIO=test2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,17 @@ install:
 env:
   - SCENARIO=test1 MOLECULE_IMAGE=centos:7
   - SCENARIO=test1 MOLECULE_IMAGE=centos:8
+<<<<<<< HEAD
   - SCENARIO=test1b MOLECULE_IMAGE=centos:7
   - SCENARIO=test1c MOLECULE_IMAGE=centos:7
   - SCENARIO=test2 MOLECULE_IMAGE=centos:7
   - SCENARIO=test3 MOLECULE_IMAGE=centos:7
+=======
+  - SCENARIO=test1b
+  - SCENARIO=test1c
+  - SCENARIO=test2
+  - SCENARIO=test3
+>>>>>>> add centos8 travis tests
 
 script:
   # Run molecule tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ install:
 env:
   - SCENARIO=test1 MOLECULE_IMAGE=centos:7
   - SCENARIO=test1 MOLECULE_IMAGE=centos:8
-  - SCENARIO=test1b
-  - SCENARIO=test1c
-  - SCENARIO=test2
-  - SCENARIO=test3
+  - SCENARIO=test1b MOLECULE_IMAGE=centos:7
+  - SCENARIO=test1c MOLECULE_IMAGE=centos:7
+  - SCENARIO=test2 MOLECULE_IMAGE=centos:7
+  - SCENARIO=test3 MOLECULE_IMAGE=centos:7
 
 script:
   # Run molecule tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,10 @@ install:
 env:
   - SCENARIO=test1 MOLECULE_IMAGE=centos:7
   - SCENARIO=test1 MOLECULE_IMAGE=centos:8
-<<<<<<< HEAD
   - SCENARIO=test1b MOLECULE_IMAGE=centos:7
   - SCENARIO=test1c MOLECULE_IMAGE=centos:7
   - SCENARIO=test2 MOLECULE_IMAGE=centos:7
   - SCENARIO=test3 MOLECULE_IMAGE=centos:7
-=======
-  - SCENARIO=test1b
-  - SCENARIO=test1c
-  - SCENARIO=test2
-  - SCENARIO=test3
->>>>>>> add centos8 travis tests
 
 script:
   # Run molecule tests

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The minimal image for nodes is a Centos7 or Centos8 cloud image. These use OpenH
 Role Variables
 --------------
 
+`openhpc_release_repo`: Optional. Path to the `ohpc-release` repo to use. Defaults provide v1.3 for Centos 7 and v2 for Centos 8. Or, include this
+package in the image.
+
 `openhpc_slurm_service_enabled`: boolean, whether to enable the appropriate slurm service (slurmd/slurmctld)
 
 `openhpc_slurm_control_host`: ansible host name of the controller e.g `"{{ groups['cluster_control'] | first }}"`
@@ -134,14 +137,3 @@ To drain nodes, for example, before scaling down the cluster to 6 nodes:
             drain: "{{ inventory_hostname not in desired_state }}"
             resume: "{{ inventory_hostname in desired_state }}"
     ...
-
-
-CentOS 8 and OpenHPC 2
-----------------------
-
-To deploy OpenHPC 2 on CentOS 8, you must first enable the CentOS PowerTools repo
-(this ships as standard, but disabled).  To enable PowerTools:
-
-```
-sudo dnf config-manager --set-enabled PowerTools
-```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ openhpc_enable:
 ohpc_slurm_services:
   control: slurmctld
   batch: slurmd
+ohpc_release_repos:
+  "7": "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm" # ohpc v1.3 for Centos 7
+  "8": "http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm" # ohpc v2 for Centos 8

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -17,7 +17,6 @@ test3  | 1            | Y                       | -
 Local installation on a Centos7 machine looks like:
 
     sudo yum install -y gcc python3-pip python3-devel openssl-devel python3-libselinux
-    sudo yum install -y docker-ce docker-ce-cli containerd.io
     sudo yum install -y yum-utils
     sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo yum install -y docker-ce docker-ce-cli containerd.io
@@ -35,5 +34,5 @@ Local installation on a Centos7 machine looks like:
 Then to run all tests:
 
     cd ansible-role-openhpc/
-    molecule test --all
-
+    MOLECULE_IMAGE=centos:7 molecule test --all
+    MOLECULE_IMAGE=centos:8 molecule test --all

--- a/molecule/test1/converge.yml
+++ b/molecule/test1/converge.yml
@@ -2,10 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Install OpenHPC repository
-      yum:
-        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
-        state: present
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "ansible-role-openhpc/"

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -4,7 +4,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -17,7 +17,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-0
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -30,7 +30,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-1
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -5,7 +5,7 @@ driver:
 platforms:
   - name: testohpc-login-0
     image: ${MOLECULE_IMAGE}
-    pre_build_image: true
+    #pre_build_image: true
     groups:
       - testohpc_login
     command: /sbin/init
@@ -18,7 +18,7 @@ platforms:
       - name: net1
   - name: testohpc-compute-0
     image: ${MOLECULE_IMAGE}
-    pre_build_image: true
+    #pre_build_image: true
     groups:
       - testohpc_compute
     command: /sbin/init
@@ -31,7 +31,7 @@ platforms:
       - name: net1
   - name: testohpc-compute-1
     image: ${MOLECULE_IMAGE}
-    pre_build_image: true
+    #pre_build_image: true
     groups:
       - testohpc_compute
     command: /sbin/init

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -5,7 +5,7 @@ driver:
 platforms:
   - name: testohpc-login-0
     image: ${MOLECULE_IMAGE}
-    #pre_build_image: true
+    pre_build_image: true
     groups:
       - testohpc_login
     command: /sbin/init
@@ -18,7 +18,7 @@ platforms:
       - name: net1
   - name: testohpc-compute-0
     image: ${MOLECULE_IMAGE}
-    #pre_build_image: true
+    pre_build_image: true
     groups:
       - testohpc_compute
     command: /sbin/init
@@ -31,7 +31,7 @@ platforms:
       - name: net1
   - name: testohpc-compute-1
     image: ${MOLECULE_IMAGE}
-    #pre_build_image: true
+    pre_build_image: true
     groups:
       - testohpc_compute
     command: /sbin/init

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -4,13 +4,8 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
-=======
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
-    pre_build_image: true
->>>>>>> add centos8 travis tests
     groups:
       - testohpc_login
     command: /sbin/init
@@ -22,13 +17,8 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-0
-<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
-=======
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
-    pre_build_image: true
->>>>>>> add centos8 travis tests
     groups:
       - testohpc_compute
     command: /sbin/init
@@ -40,13 +30,8 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-1
-<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
-=======
-    image: docker.io/pycontribs/${MOLECULE_IMAGE}
-    pre_build_image: true
->>>>>>> add centos8 travis tests
     groups:
       - testohpc_compute
     command: /sbin/init

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -4,8 +4,13 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
+<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
+=======
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    pre_build_image: true
+>>>>>>> add centos8 travis tests
     groups:
       - testohpc_login
     command: /sbin/init
@@ -17,8 +22,13 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-0
+<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
+=======
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    pre_build_image: true
+>>>>>>> add centos8 travis tests
     groups:
       - testohpc_compute
     command: /sbin/init
@@ -30,8 +40,13 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-1
+<<<<<<< HEAD
     image: ${MOLECULE_IMAGE}
     #pre_build_image: true
+=======
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
+    pre_build_image: true
+>>>>>>> add centos8 travis tests
     groups:
       - testohpc_compute
     command: /sbin/init

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -4,7 +4,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/centos:7
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -17,7 +17,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-0
-    image: docker.io/pycontribs/centos:7
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -30,7 +30,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-1
-    image: docker.io/pycontribs/centos:7
+    image: docker.io/pycontribs/${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/molecule/test1/verify.yml
+++ b/molecule/test1/verify.yml
@@ -4,9 +4,9 @@
   hosts: testohpc_login
   tasks:
   - name: Get slurm partition info
-    command: sinfo -h
+    command: sinfo --noheader --format="%P,%a,%l,%D,%t,%N" # using --format ensures we control whitespace
     register: sinfo
   - name: 
     assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
-      that: "sinfo.stdout_lines == ['compute*     up 60-00:00:0      2   idle testohpc-compute-[0-1]']"
+      that: "sinfo.stdout_lines == ['compute*,up,60-00:00:00,2,idle,testohpc-compute-[0-1]']"
       fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/molecule/test1b/converge.yml
+++ b/molecule/test1b/converge.yml
@@ -2,10 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Install OpenHPC repository
-      yum:
-        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
-        state: present
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "ansible-role-openhpc/"

--- a/molecule/test1b/molecule.yml
+++ b/molecule/test1b/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -19,7 +19,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-compute-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/molecule/test1b/verify.yml
+++ b/molecule/test1b/verify.yml
@@ -4,9 +4,9 @@
   hosts: testohpc_login
   tasks:
   - name: Get slurm partition info
-    command: sinfo -h
+    command: sinfo --noheader --format="%P,%a,%l,%D,%t,%N" # using --format ensures we control whitespace
     register: sinfo
   - name: 
     assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
-      that: "sinfo.stdout_lines == ['compute*     up 60-00:00:0      1   idle testohpc-compute-0']"
+      that: "sinfo.stdout_lines == ['compute*,up,60-00:00:00,1,idle,testohpc-compute-0']"
       fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/molecule/test1c/converge.yml
+++ b/molecule/test1c/converge.yml
@@ -2,10 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Install OpenHPC repository
-      yum:
-        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
-        state: present
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "ansible-role-openhpc/"

--- a/molecule/test1c/molecule.yml
+++ b/molecule/test1c/molecule.yml
@@ -4,7 +4,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -17,7 +17,7 @@ platforms:
     networks:
       - name: net1
   - name: compute-a
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -30,7 +30,7 @@ platforms:
     networks:
       - name: net1
   - name: compute10
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/molecule/test1c/verify.yml
+++ b/molecule/test1c/verify.yml
@@ -3,9 +3,9 @@
   hosts: testohpc_login
   tasks:
   - name: Get slurm partition info
-    command: sinfo -h sinfo --Node -S "+N" # 1 line per node, sort by increasing node name
+    command: sinfo --noheader --format="%P,%a,%l,%D,%t,%N" # using --format ensures we control whitespace
     register: sinfo
   - name: 
     assert:
-      that: "sinfo.stdout_lines == ['compute-a      1  compute* idle  ', 'compute10      1  compute* idle  ']"
+      that: "sinfo.stdout_lines == ['compute*,up,60-00:00:00,2,idle,compute10,compute-a']"
       fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/molecule/test2/converge.yml
+++ b/molecule/test2/converge.yml
@@ -2,10 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Install OpenHPC repository
-      yum:
-        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
-        state: present
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "ansible-role-openhpc/"

--- a/molecule/test2/molecule.yml
+++ b/molecule/test2/molecule.yml
@@ -4,7 +4,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -17,7 +17,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-part1-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -31,7 +31,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-part1-1
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-part2-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -59,7 +59,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-part2-1
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/molecule/test3/converge.yml
+++ b/molecule/test3/converge.yml
@@ -2,10 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Install OpenHPC repository
-      yum:
-        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
-        state: present
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "ansible-role-openhpc/"

--- a/molecule/test3/molecule.yml
+++ b/molecule/test3/molecule.yml
@@ -4,7 +4,7 @@ driver:
   name: docker
 platforms:
   - name: testohpc-login-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_login
@@ -17,7 +17,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-grp1-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -31,7 +31,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-grp1-1
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-grp2-0
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute
@@ -59,7 +59,7 @@ platforms:
     networks:
       - name: net1
   - name: testohpc-grp2-1
-    image: docker.io/pycontribs/centos:7
+    image: ${MOLECULE_IMAGE}
     pre_build_image: true
     groups:
       - testohpc_compute

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,22 +1,29 @@
 ---
 
-# Validate package facts and include version-specific config
 - name: Gather package facts
   package_facts:
     manager: rpm
 
-- name: Check ohpc-release package is installed
-  assert:
-    that: "'ohpc-release' in ansible_facts.packages"
-    quiet: yes
-    fail_msg: |
-      "The OpenHPC distro package should be installed in the image.
-       Please see http://openhpc.community/downloads/"
+- name: Install ohpc-release package
+  yum:
+    name: "{{ openhpc_release_repo | default(ohpc_release_repos[ansible_distribution_major_version]) }}"
+    state: present
+  when: "'ohpc-release' not in ansible_facts.packages"
+
+- name: Update package facts
+  package_facts:
+    manager: rpm
 
 - name: Include variables for OpenHPC version
   include_vars:
     file: "ohpc-{{ ansible_facts.packages['ohpc-release'][0]['version'] }}"
 
+- name: Enable CentOS8 PowerTools repo
+  command: dnf config-manager --set-enabled PowerTools
+  args:
+    warn: false
+  when: ansible_distribution_major_version == "8"
+  
 - name: Build host-specific list of required slurm packages
   set_fact:
     openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + item.value }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,9 +19,12 @@
     file: "ohpc-{{ ansible_facts.packages['ohpc-release'][0]['version'] }}"
 
 - name: Enable CentOS8 PowerTools repo
-  command: dnf config-manager --set-enabled PowerTools
-  args:
-    warn: false
+  # NB: doesn't run command  `dnf config-manager --set-enabled PowerTools` as can't make that idempotent
+  lineinfile: 
+    path: /etc/yum.repos.d/CentOS-PowerTools.repo
+    create: false # raises error if not already installed
+    regexp: enabled=
+    line: enabled=1
   when: ansible_distribution_major_version == "8"
 
 - name: Build host-specific list of required slurm packages

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,8 +23,8 @@
   args:
     warn: false
   when: ansible_distribution_major_version == "8"
-  
-- name: Build host-specific list of required slurm packages
+
+  - name: Build host-specific list of required slurm packages
   set_fact:
     openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + item.value }}"
   loop: "{{ ohpc_slurm_packages | dict2items }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,7 +24,7 @@
     warn: false
   when: ansible_distribution_major_version == "8"
 
-  - name: Build host-specific list of required slurm packages
+- name: Build host-specific list of required slurm packages
   set_fact:
     openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + item.value }}"
   loop: "{{ ohpc_slurm_packages | dict2items }}"


### PR DESCRIPTION
Removes the need for users of this role to configure two aspects outside of the role:
- Installs an `ohpc-release` repo (see #6), appropriate for the Centos version (but if one's already present in the image, it won't try to change it)
- Enables `PowerTools` repo on Centos8 (see #41)

Given these changes it also adds a test on centos 8. Currently centos8 test fails _on travis_ as ohpc-release repo fails GPG key check, however tests directly on molecule (using same image!) run as follows:

    git checkout auto-centos8
    git pull
    MOLECULE_IMAGE=centos:7 molecule test --all # PASSES
    MOLECULE_IMAGE=centos:8 molecule test --all # PASSES


(the commits on this are messy due to a failed rebase onto master but the diff looks good).