### PR TITLE
Introduce flag to control whether or not services are started

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package in the image.
 
 `openhpc_slurm_service_enabled`: boolean, whether to enable the appropriate slurm service (slurmd/slurmctld)
 
-`openhpc_slurm_service_started`: boolean, whether to start the appropriate slurm service (slurmd/slurmctld)
+`openhpc_slurm_service_started`: Optional boolean. Whether to start slurm services. If set to false, all services will be stopped. Defaults to `openhpc_slurm_service_enabled`.
 
 `openhpc_slurm_control_host`: ansible host name of the controller e.g `"{{ groups['cluster_control'] | first }}"`
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ package in the image.
 
 `openhpc_slurm_service_enabled`: boolean, whether to enable the appropriate slurm service (slurmd/slurmctld)
 
+`openhpc_slurm_service_started`: boolean, whether to start the appropriate slurm service (slurmd/slurmctld)
+
 `openhpc_slurm_control_host`: ansible host name of the controller e.g `"{{ groups['cluster_control'] | first }}"`
 
 `openhpc_slurm_partitions`: list of one or more slurm partitions.  Each partition may contain the following values:
@@ -24,9 +26,9 @@ package in the image.
   * `name`: The name of the nodes within this group.
   * `cluster_name`: Optional.  An override for the top-level definition `openhpc_cluster_name`.
   * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`). This is set to the Slurm default of `1` if not defined.
-  
+
   For each group (if used) or partition there must be an ansible inventory group `<cluster_name>_<group_name>`. All nodes in this inventory group will be added to the group/partition. Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname. Nodes in a group are assumed to be homogenous in terms of processor and memory.
-  
+
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is
   given by `openhpc_job_maxtime`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 openhpc_slurm_service_enabled: true
+openhpc_slurm_service_started: "{{ openhpc_slurm_service_enabled }}"
 openhpc_slurm_service:
 openhpc_slurm_control_host: "{{ inventory_hostname }}"
 openhpc_slurm_partitions: []
@@ -12,9 +13,9 @@ openhpc_job_maxtime: 24:00:00
 openhpc_enable:
   control: false
   batch: false
-  runtime: false 
-  drain: false 
-  resume: false 
+  runtime: false
+  drain: false
+  resume: false
 ohpc_slurm_services:
   control: slurmctld
   batch: slurmd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,10 +5,10 @@
     state: reloaded
   when:
     - openhpc_slurm_service is not none
-    - openhpc_slurm_service_enabled | bool
+    - openhpc_slurm_service_started | bool
 
 - name: Restart Munge service
   service:
     name: "munge"
     state: restarted
-  when: openhpc_slurm_service_enabled | bool
+  when: openhpc_slurm_service_started | bool

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -15,13 +15,6 @@
     mode: 0755
     state: directory
 
-- name: Ensure the Munge service is enabled
-  service:
-    name: munge
-    enabled: "{{ openhpc_slurm_service_enabled | bool }}"
-  notify:
-    - Restart Munge service
-
 - name: Generate a Munge key for the platform
   command: "dd if=/dev/urandom of=/etc/munge/munge.key bs=1 count=1024"
   args:
@@ -44,14 +37,6 @@
   notify:
     - Restart Munge service
 
-- name: Ensure Slurm services are enabled
-  service:
-    name: "{{ openhpc_slurm_service }}"
-    enabled: "{{ openhpc_slurm_service_enabled | bool }}"
-  when: openhpc_slurm_service is not none
-  notify:
-    - Restart SLURM service
-
 - name: Apply customised SLURM configuration
   template:
     src: slurm.conf.j2
@@ -67,7 +52,7 @@
 
 # Munge state could be unchanged but the service is not running.
 # Handle that here.
-- name: Ensure Munge services are enabled and started
+- name: Configure Munge service
   service:
     name: munge
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
@@ -75,8 +60,9 @@
 
 # In case the service isn't running and the config hasn't changed to trigger
 # the handler, ensure it's running here.
-- name: Ensure Slurm services are running
+- name: Configure Slurm service
   service:
     name: "{{ openhpc_slurm_service }}"
+    enabled: "{{ openhpc_slurm_service_enabled | bool }}"
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_slurm_service is not none

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -71,12 +71,12 @@
   service:
     name: munge
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
-    state: "{{ 'started' if openhpc_slurm_service_enabled | bool else 'stopped' }}"
+    state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
 
 # In case the service isn't running and the config hasn't changed to trigger
 # the handler, ensure it's running here.
 - name: Ensure Slurm services are running
   service:
     name: "{{ openhpc_slurm_service }}"
-    state: "{{ 'started' if openhpc_slurm_service_enabled | bool else 'stopped' }}"
+    state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_slurm_service is not none


### PR DESCRIPTION
This should be backwards compatible as it defaults to `openhpc_slurm_service_enabled`, which was used to start the services previously.