### PR TITLE
Fix slurm.conf templating when more than one group/partition

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -109,6 +109,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
 {%      set group_hosts = groups[group_name] | intersect(play_hosts) %}
 {%      set first_host = group_hosts | first | mandatory('Group "' + group_name + '" contains no hosts in this play - was --limit used?') %}
 {%      set first_host_hv = hostvars[first_host] %}
+
 NodeName=DEFAULT State=UNKNOWN \
     RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}1{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
@@ -125,7 +126,8 @@ PartitionName={{part.name}} \
     Nodes=\
 {%   for group in part.get('groups', [part]) %}
 {%   set group_name = group.cluster_name|default(openhpc_cluster_name) ~ '_' ~ group.name %}
-{{ groups[group_name] | join(",\\\n") }}{% if not loop.last %},\
+{{ groups[group_name] | join(",\\\n") }}{% if not loop.last %},\{% else %}
+
 {% endif %}
 {%   endfor %}{# group #}
 {% endfor %}{# partitions #}


### PR DESCRIPTION
Without this the config file is missing a newline:

```
NodeName=DEFAULT State=UNKNOWN \
    RealMemory=1 \
    Sockets=1 \
    CoresPerSocket=4 \
    ThreadsPerCore=2
NodeName=testohpc-part1-0
NodeName=testohpc-part1-1
PartitionName=part1 \
    Default=YES \
    MaxTime=86400 \
    State=UP \
    Nodes=\
testohpc-part1-0,\
testohpc-part1-1NodeName=DEFAULT State=UNKNOWN \ # should be \n after testohpc-part1-1
    RealMemory=1 \
    Sockets=1 \
    CoresPerSocket=4 \
    ThreadsPerCore=2
NodeName=testohpc-part2-0
NodeName=testohpc-part2-1
PartitionName=part2 \
    Default=YES \
    MaxTime=86400 \
    State=UP \
    Nodes=\
testohpc-part2-0,\
testohpc-part2-1
```

Also adds spaces between partitions/groups in the config to make it easier to read.