### PR TITLE
bugfix slurmd startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'centos:8'
+          - 'centos:8.2'
           - 'centos:7'
         scenario:
           - test1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'centos:8.2'
+          - 'centos:8.2.2004'
           - 'centos:7'
         scenario:
           - test1

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -38,3 +38,7 @@ Then to run all tests:
     cd ansible-role-openhpc/
     MOLECULE_IMAGE=centos:7 molecule test --all
     MOLECULE_IMAGE=centos:8 molecule test --all
+
+Note that to see some debugging information you may want to prepend:
+
+    MOLECULE_NO_LOG="false" ...

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,3 @@
 pip
 setuptools
-molecule[lint]
-docker
+molecule[docker,lint]

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -25,6 +25,8 @@
   args:
     creates: "/etc/munge/munge.key"
   when: inventory_hostname == openhpc_slurm_control_host
+  notify:
+    - Restart Munge service
 
 - name: Retrieve Munge key from Slurm control host
   slurp:
@@ -77,9 +79,6 @@
   notify:
     - Reload SLURM service
 
-- name: Flush handlers
-  meta: flush_handlers
-
 # Munge state could be unchanged but the service is not running.
 # Handle that here.
 - name: Configure Munge service
@@ -103,3 +102,5 @@
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_slurm_service is not none
+  retries: 3
+  delay: 20

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -102,5 +102,3 @@
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_slurm_service is not none
-  retries: 3
-  delay: 20


### PR DESCRIPTION
Fixes #72 by removing flush_handlers so that the "Configure munge service" play has a chance to start munged before slurmctld/slurmd.

Note that the "notify" added to the "Generate a Munge key for the platform" task is NOT actually enough to trigger the handlers on a new build here - the munge package appears to install /etc/munge/munge.key therefore this task isn't a change.