### PR TITLE
fix slurmd startup on new cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'centos:8'
+          - 'centos:8.2'
           - 'centos:7'
         scenario:
           - test1

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -62,6 +62,7 @@
     lstrip_blocks: true
   when: openhpc_enable.control or not openhpc_slurm_configless
   notify:
+    - Restart Munge service
     - Reload SLURM service
 
 - name: Set slurmctld location for configless operation


### PR DESCRIPTION
2nd attempt:
- triggers munge handler on slurm.conf template out, which changes on control node on a clean build.
- is idempotent
- if we're reloading slurmd on a slurm.conf change, I think restarting munged is ok
- much simpler than changing the munge key location (which feels overly complicated to me!)
... but you still may not like it!