### PR TITLE
Install slurm-libpmi-ohpc by default so srun works with intel mpi

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,8 @@ openhpc_slurm_service:
 openhpc_slurm_control_host: "{{ inventory_hostname }}"
 openhpc_slurm_partitions: []
 openhpc_cluster_name:
-openhpc_packages: []
+openhpc_packages:
+  - slurm-libpmi-ohpc
 openhpc_drain_timeout: 86400
 openhpc_resume_timeout: 300
 openhpc_retry_delay: 10


### PR DESCRIPTION
See title