### PR TITLE
default node memory for slurm.conf set from ansible facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ package in the image.
   Otherwise, `groups` can be omitted and the following attributes can be defined in the partition object:
   * `name`: The name of the nodes within this group.
   * `cluster_name`: Optional.  An override for the top-level definition `openhpc_cluster_name`.
-  * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`). This is set to the Slurm default of `1` if not defined.
+  * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`) in MB. This is set to the total real memory from ansible facts if not defined (equivalent to `free --mebi` total).
 
   For each group (if used) or partition there must be an ansible inventory group `<cluster_name>_<group_name>`. All nodes in this inventory group will be added to the group/partition. Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname. Nodes in a group are assumed to be homogenous in terms of processor and memory.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ package in the image.
   Otherwise, `groups` can be omitted and the following attributes can be defined in the partition object:
   * `name`: The name of the nodes within this group.
   * `cluster_name`: Optional.  An override for the top-level definition `openhpc_cluster_name`.
-  * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`) in MB. This is set to the total real memory from ansible facts if not defined (equivalent to `free --mebi` total).
+  * `ram_mb`: Optional.  The physical RAM available in each server of this group ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `RealMemory`) in MiB. This is set to the total real memory from ansible facts if not defined (equivalent to `free --mebi` total).
 
   For each group (if used) or partition there must be an ansible inventory group `<cluster_name>_<group_name>`. All nodes in this inventory group will be added to the group/partition. Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname. Nodes in a group are assumed to be homogenous in terms of processor and memory.
 

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -113,7 +113,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
         {% set first_host = group_hosts | first | mandatory('Group "' + group_name + '" contains no hosts in this play - was --limit used?') %}
         {% set first_host_hv = hostvars[first_host] %}
 NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}1{% endif %} \
+    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] }}{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}


### PR DESCRIPTION
Currently node memory defaults to 1MB if `ram_mb` not set in role vars. This changes the default to the real free memory as given from ansible facts. Given the number of cpu cores etc is set from facts this seems uncontrovertial.