### PR TITLE
Fix login-only nodes in configless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ package in the image.
 * `control`: whether to enable control host
 * `database`: whether to enable slurmdbd
 * `batch`: whether to enable compute nodes
-* `login`: whether to enable login-only nodes in configless mode (for combined control/login nodes this can be left false)
 * `runtime`: whether to enable OpenHPC runtime
 * `drain`: whether to drain compute nodes
 * `resume`: whether to resume compute nodes
 
 `openhpc_slurmdbd_host`: Optional. Where to deploy slurmdbd if are using this role to deploy slurmdbd, otherwise where an existing slurmdbd is running. This should be the name of a host in your inventory. Set this to `none` to prevent the role from managing slurmdbd. Defaults to `openhpc_slurm_control_host`.
 
-`openhpc_slurm_configless`: Optional, default false. If True then slurm's ["configless" mode](https://slurm.schedmd.com/configless_slurm.html) is used. **NB: Requires Centos8/OpenHPC v2.**
+`openhpc_slurm_configless`: Optional, default false. If true then slurm's ["configless" mode](https://slurm.schedmd.com/configless_slurm.html) is used. **NB: Requires Centos8/OpenHPC v2.**
 
 `openhpc_munge_key_path`: Optional, default ''. Define a path for a local file containing a munge key to use, otherwise one will be generated on the slurm control node.
+
+`openhpc_login_only_nodes`: Optional. If using "configless" mode specify the name of an ansible group containing nodes which are login-only nodes (i.e. not also control nodes), if required. These nodes will run `slurmd` to contact the control node for config.
 
 ### slurm.conf
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ package in the image.
 * `control`: whether to enable control host
 * `database`: whether to enable slurmdbd
 * `batch`: whether to enable compute nodes
+* `login`: whether to enable login-only nodes in configless mode (for combined control/login nodes this can be left false)
 * `runtime`: whether to enable OpenHPC runtime
 * `drain`: whether to drain compute nodes
 * `resume`: whether to resume compute nodes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ openhpc_slurmdbd_mysql_username: slurm
 openhpc_enable:
   control: false
   batch: false
+  login: true
   database: false
   runtime: false
   drain: false
@@ -45,6 +46,7 @@ openhpc_enable:
 ohpc_slurm_services:
   control: slurmctld
   batch: slurmd
+  login: slurmd
 ohpc_release_repos:
   "7": "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm" # ohpc v1.3 for Centos 7
   "8": "http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm" # ohpc v2 for Centos 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,6 @@ openhpc_slurmdbd_mysql_username: slurm
 openhpc_enable:
   control: false
   batch: false
-  login: true
   database: false
   runtime: false
   drain: false
@@ -52,3 +51,4 @@ ohpc_release_repos:
   "8": "http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm" # ohpc v2 for Centos 8
 openhpc_slurm_configless: false
 openhpc_munge_key: ''
+openhpc_login_only_nodes: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,6 @@ openhpc_enable:
 ohpc_slurm_services:
   control: slurmctld
   batch: slurmd
-  login: slurmd
 ohpc_release_repos:
   "7": "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm" # ohpc v1.3 for Centos 7
   "8": "http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm" # ohpc v2 for Centos 8

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -16,6 +16,7 @@ test5  | 1            | N                       | As for #1 but configless
 test6  | 1            | N                       | 0x compute nodes, configless
 test7  | 1            | N                       | 1x compute node, no login node, configless
 test8  | 1            | N                       | 2x compute node, 2x login-only nodes, configless
+test9  | 1            | N                       | As test8 but uses `--limit=testohpc-control,testohpc-compute-0` and checks login nodes still end up in slurm.conf
 
 # Local Installation & Running
 

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -15,6 +15,7 @@ test4  | 1            | N                       | 2x compute node, accounting en
 test5  | 1            | N                       | As for #1 but configless
 test6  | 1            | N                       | 0x compute nodes, configless
 test7  | 1            | N                       | 1x compute node, no login node, configless
+test8  | 1            | N                       | 2x compute node, 2x login-only nodes, configless
 
 # Local Installation & Running
 

--- a/molecule/test8/INSTALL.rst
+++ b/molecule/test8/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/test8/converge.yml
+++ b/molecule/test8/converge.yml
@@ -16,4 +16,5 @@
           - name: "compute"
         openhpc_cluster_name: testohpc
         openhpc_slurm_configless: true
+        openhpc_login_only_nodes: 'testohpc_login'
 

--- a/molecule/test8/converge.yml
+++ b/molecule/test8/converge.yml
@@ -9,7 +9,6 @@
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_control'] }}"
           batch: "{{ inventory_hostname in groups['testohpc_compute'] }}"
-          login: "{{  inventory_hostname in groups['testohpc_login'] }}"
           runtime: true
         openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
         openhpc_slurm_partitions:

--- a/molecule/test8/converge.yml
+++ b/molecule/test8/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-openhpc"
+      include_role:
+        name: "ansible-role-openhpc/"
+      vars:
+        openhpc_enable:
+          control: "{{ inventory_hostname in groups['testohpc_control'] }}"
+          batch: "{{ inventory_hostname in groups['testohpc_compute'] }}"
+          login: "{{  inventory_hostname in groups['testohpc_login'] }}"
+          runtime: true
+        openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
+        openhpc_slurm_partitions:
+          - name: "compute"
+        openhpc_cluster_name: testohpc
+        openhpc_slurm_configless: true
+

--- a/molecule/test8/molecule.yml
+++ b/molecule/test8/molecule.yml
@@ -1,0 +1,77 @@
+---
+name: single partition, group is partition
+driver:
+  name: docker
+platforms:
+  - name: testohpc-control
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_control
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+      
+  - name: testohpc-login-0
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_login
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+
+  - name: testohpc-login-1
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_login
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+  
+  - name: testohpc-compute-0
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_compute
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+  - name: testohpc-compute-1
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_compute
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/test8/molecule.yml
+++ b/molecule/test8/molecule.yml
@@ -73,5 +73,7 @@ platforms:
       - name: net1
 provisioner:
   name: ansible
+  # ansible_args:
+  #   - --limit=testohpc-control,testohpc-compute-0
 verifier:
   name: ansible

--- a/molecule/test8/verify.yml
+++ b/molecule/test8/verify.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Check slurm hostlist
+  hosts: testohpc_login # NB for this test this is 2x non-control nodes, so tests they can contact slurmctld too
+  tasks:
+  - name: Get slurm partition info
+    command: sinfo --noheader --format="%P,%a,%l,%D,%t,%N" # using --format ensures we control whitespace
+    register: sinfo
+  - name: 
+    assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+      that: "sinfo.stdout_lines == ['compute*,up,60-00:00:00,2,idle,testohpc-compute-[0-1]']"
+      fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/molecule/test9/INSTALL.rst
+++ b/molecule/test9/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/test9/converge.yml
+++ b/molecule/test9/converge.yml
@@ -9,7 +9,6 @@
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_control'] }}"
           batch: "{{ inventory_hostname in groups['testohpc_compute'] }}"
-          login: "{{  inventory_hostname in groups['testohpc_login'] }}"
           runtime: true
         openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
         openhpc_slurm_partitions:

--- a/molecule/test9/converge.yml
+++ b/molecule/test9/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-openhpc"
+      include_role:
+        name: "ansible-role-openhpc/"
+      vars:
+        openhpc_enable:
+          control: "{{ inventory_hostname in groups['testohpc_control'] }}"
+          batch: "{{ inventory_hostname in groups['testohpc_compute'] }}"
+          login: "{{  inventory_hostname in groups['testohpc_login'] }}"
+          runtime: true
+        openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
+        openhpc_slurm_partitions:
+          - name: "compute"
+        openhpc_cluster_name: testohpc
+        openhpc_slurm_configless: true
+        openhpc_login_only_nodes: 'testohpc_login'
+

--- a/molecule/test9/molecule.yml
+++ b/molecule/test9/molecule.yml
@@ -1,0 +1,79 @@
+---
+name: single partition, group is partition
+driver:
+  name: docker
+platforms:
+  - name: testohpc-control
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_control
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+      
+  - name: testohpc-login-0
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_login
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+
+  - name: testohpc-login-1
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_login
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+  
+  - name: testohpc-compute-0
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_compute
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+  - name: testohpc-compute-1
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_compute
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+provisioner:
+  name: ansible
+  ansible_args:
+    - --limit=testohpc-control,testohpc-compute-0
+verifier:
+  name: ansible

--- a/molecule/test9/verify.yml
+++ b/molecule/test9/verify.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: testohpc_control
+  tasks:
+  - name: Check both compute nodes are listed and compute-0 is up
+    shell: 'sinfo --noheader --Node --format="%P,%a,%l,%D,%t,%N"' # using --format ensures we control whitespace
+    register: sinfo
+  - assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+      that: "sinfo.stdout_lines == ['compute*,up,60-00:00:00,1,idle,testohpc-compute-0','compute*,up,60-00:00:00,1,unk*,testohpc-compute-1']" # NB: -1 goes 'down' after a while!
+      fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"
+  - name: Check login nodes in config
+    command: "grep NodeName={{ item }} /etc/slurm/slurm.conf"
+    loop: "{{ groups['testohpc_login'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   when: "openhpc_enable.get(item, false)"
   tags: always
 
+- name: Set slurmd as service for openhpc_login_only_nodes
+  set_fact:
+    openhpc_slurm_service: "slurmd"
+  when: openhpc_login_only_nodes and (openhpc_login_only_nodes in group_names)
+
 - name: Install packages
   block:
     - include_tasks: install.yml

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -43,11 +43,6 @@
   notify:
     - Restart Munge service
 
-- name: Set fact for login-only nodes
-  # needed b/c openhpc_enable doesn't end up in hostvars
-  set_fact:
-    openhpc_login_only: "{{ openhpc_enable.login | default(false) | bool }}"
-
 - name: Template slurmdbd.conf
   template:
     src: slurmdbd.conf.j2
@@ -80,7 +75,7 @@
     group: root
     mode: 0644
   when:
-    - (openhpc_enable.batch | default(false) | bool) or (openhpc_enable.login | default(false) | bool)
+    - openhpc_slurm_service == 'slurmd'
     - openhpc_slurm_configless
   notify:
     - Reload SLURM service

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -43,6 +43,11 @@
   notify:
     - Restart Munge service
 
+- name: Set fact for login-only nodes
+  # needed b/c openhpc_enable doesn't end up in hostvars
+  set_fact:
+    openhpc_login_only: "{{ openhpc_enable.login | default(false) | bool }}"
+  
 - name: Template slurmdbd.conf
   template:
     src: slurmdbd.conf.j2
@@ -75,7 +80,7 @@
     group: root
     mode: 0644
   when:
-    - openhpc_enable.batch | default(false) | bool
+    - (openhpc_enable.batch | default(false) | bool) or (openhpc_enable.login | default(false) | bool)
     - openhpc_slurm_configless
   notify:
     - Reload SLURM service

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -47,7 +47,7 @@
   # needed b/c openhpc_enable doesn't end up in hostvars
   set_fact:
     openhpc_login_only: "{{ openhpc_enable.login | default(false) | bool }}"
-  
+
 - name: Template slurmdbd.conf
   template:
     src: slurmdbd.conf.j2

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -139,11 +139,9 @@ PartitionName={{part.name}} \
 
 
 # Define slurmd nodes not in partitions for configless login-only nodes:
-{% for node in hostvars %}
-    {% if hostvars[node].openhpc_login_only %}
+{%if openhpc_login_only_nodes %}{% for node in groups[openhpc_login_only_nodes] %}
 NodeName={{ node }}
-    {% endif %}
-{% endfor %}{# configless login-only #}
+{% endfor %}{% endif %}
 
 # Want nodes that drop out of SLURM's configuration to be automatically
 # returned to service when they come back.

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -137,6 +137,14 @@ PartitionName={{part.name}} \
         {% endfor %}{# group #}
 {% endfor %}{# partitions #}
 
+
+# Define slurmd nodes not in partitions for configless login-only nodes:
+{% for node in hostvars %}
+    {% if hostvars[node].openhpc_login_only %}
+NodeName={{ node }}
+    {% endif %}
+{% endfor %}{# configless login-only #}
+
 # Want nodes that drop out of SLURM's configuration to be automatically
 # returned to service when they come back.
 ReturnToService=2


### PR DESCRIPTION
In configless mode compute nodes have an environment var set to tell slurmd what the the slurmctld host is. Login-only nodes don't have this so slurm commands can't work.

There are three possible approaches ([docs](https://slurm.schedmd.com/configless_slurm.html)):
1. Use DNS SRV records to provide the slurmctld host name - not under control of this role, so can rule that out.
2. Template the config onto the login nodes - could do that, but then login images aren't "fixed" and have multiple possible sources-of-truth for cluster config when resizing etc, so don't like that.
3. Run slurmd on the login nodes - this is the docs suggestion when 1) isn't possible.

This PR implements 3). I don't particularly like the implementation but here's why it is the best I could come up with:
1. The current "runtime"-node package list (in e.g. `vars/ohpc-2`) already includes packages for slurmd.
2. We need `ohpc_slurm_services = slurmd` so that slurmd gets configured. This _could_ be done simply by setting `openhpc_enable.batch=True`.
3. The slurm.conf needs a `NodeName` entry for each login-only node. Entries don't need any other information and don't need to be included in any partition.
4. Due to the `openhpc_slurm_partitions` design its very hard to extract the set of `batch` nodes which aren't listed in any partition. (This set is the login-only nodes). Therefore a new `openhpc_enable.login` flag is added to explicitly identify such nodes, rather than setting `.batch = True`.
5. As `openhpc_enable` is a role var it doesn't end up in hostvars so there's no way to find the `.login` nodes from within the templating. Hence, `runtime.yml` has to set a fact `openhpc_login_only` to get this info into hostvars (I considered calling this `openhpc_enable_login` but thought the similarity to `openhpc_enable.login` would actually be confusing not helpful).

