### PR TITLE
Environment module system now optional, but enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ package in the image.
 
 `openhpc_login_only_nodes`: Optional. If using "configless" mode specify the name of an ansible group containing nodes which are login-only nodes (i.e. not also control nodes), if required. These nodes will run `slurmd` to contact the control node for config.
 
+`openhpc_module_system_install`: Optional, default true. Whether or not to install an environment module system. If true, lmod will be installed. If false, You can either supply your own module system or go without one.
+
 ### slurm.conf
 
 `openhpc_slurm_partitions`: list of one or more slurm partitions.  Each partition may contain the following values:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,4 @@ ohpc_release_repos:
 openhpc_slurm_configless: false
 openhpc_munge_key: ''
 openhpc_login_only_nodes: ''
+openhpc_module_system_install: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,9 +37,10 @@
 
 - name: Build host-specific list of required slurm packages
   set_fact:
-    openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + item.value }}"
+    openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + (item.value | selectattr('install', 'true') | map(attribute='name') | list) }}"
   loop: "{{ ohpc_slurm_packages | dict2items }}"
-  when: "openhpc_enable.get(item.key, false)"
+  when:
+    - openhpc_enable.get(item.key, false)
 
 - name: Install required slurm packages
   yum:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,14 +37,13 @@
 
 - name: Build host-specific list of required slurm packages
   set_fact:
-    openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + (item.value | selectattr('install', 'true') | map(attribute='name') | list) }}"
+    openhpc_slurm_pkglist: "{{ openhpc_slurm_pkglist | default([]) + item.value }}"
   loop: "{{ ohpc_slurm_packages | dict2items }}"
-  when:
-    - openhpc_enable.get(item.key, false)
+  when: openhpc_enable.get(item.key, false)
 
 - name: Install required slurm packages
   yum:
-    name: "{{ openhpc_slurm_pkglist }}"
+    name: "{{ openhpc_slurm_pkglist | reject('eq', '') }}"
   when: openhpc_slurm_pkglist | default(false, true)
 
 - name: Install packages from openhpc_packages variable

--- a/vars/ohpc-1.3
+++ b/vars/ohpc-1.3
@@ -3,29 +3,18 @@
 
 ohpc_slurm_packages:
   control:
-    - name: "@ohpc-slurm-server"
-      install: true
-    - name: "slurm-slurmctld-ohpc"
-      install: true
-    - name: "slurm-example-configs-ohpc"
-      install: true
+    - "@ohpc-slurm-server"
+    - "slurm-slurmctld-ohpc"
+    - "slurm-example-configs-ohpc"
   batch:
-    - name: "@ohpc-base-compute"
-      install: true
-    - name: "@ohpc-slurm-client"
-      install: true
+    - "@ohpc-base-compute"
+    - "@ohpc-slurm-client"
   runtime:
-    - name: "slurm-ohpc"
-      install: true
-    - name: "munge-ohpc"
-      install: true
-    - name: "slurm-slurmd-ohpc"
-      install: true
-    - name: "slurm-example-configs-ohpc"
-      install: true
-    - name: "lmod-ohpc"
-      install: "{{ openhpc_module_system_install }}"
+    - "slurm-ohpc"
+    - "munge-ohpc"
+    - "slurm-slurmd-ohpc"
+    - "slurm-example-configs-ohpc"
+    - "{{ 'lmod-ohpc' if openhpc_module_system_install else '' }}"
   database:
-    - name: "slurm-slurmdbd-ohpc"
-      install: true
+    - "slurm-slurmdbd-ohpc"
 ...

--- a/vars/ohpc-1.3
+++ b/vars/ohpc-1.3
@@ -3,18 +3,29 @@
 
 ohpc_slurm_packages:
   control:
-    - "@ohpc-slurm-server"
-    - "slurm-slurmctld-ohpc"
-    - "slurm-example-configs-ohpc"
+    - name: "@ohpc-slurm-server"
+      install: true
+    - name: "slurm-slurmctld-ohpc"
+      install: true
+    - name: "slurm-example-configs-ohpc"
+      install: true
   batch:
-    - "@ohpc-base-compute"
-    - "@ohpc-slurm-client"
+    - name: "@ohpc-base-compute"
+      install: true
+    - name: "@ohpc-slurm-client"
+      install: true
   runtime:
-    - "slurm-ohpc"
-    - "munge-ohpc"
-    - "slurm-slurmd-ohpc"
-    - "slurm-example-configs-ohpc"
-    - "lmod-ohpc"
+    - name: "slurm-ohpc"
+      install: true
+    - name: "munge-ohpc"
+      install: true
+    - name: "slurm-slurmd-ohpc"
+      install: true
+    - name: "slurm-example-configs-ohpc"
+      install: true
+    - name: "lmod-ohpc"
+      install: "{{ openhpc_module_system_install }}"
   database:
-    - "slurm-slurmdbd-ohpc"
+    - name: "slurm-slurmdbd-ohpc"
+      install: true
 ...

--- a/vars/ohpc-2
+++ b/vars/ohpc-2
@@ -3,18 +3,29 @@
 
 ohpc_slurm_packages:
   control:
-    - "ohpc-slurm-server"
-    - "slurm-slurmctld-ohpc"
-    - "slurm-example-configs-ohpc"
+    - name: "ohpc-slurm-server"
+      install: true
+    - name: "slurm-slurmctld-ohpc"
+      install: true
+    - name: "slurm-example-configs-ohpc"
+      install: true
   batch:
-    - "ohpc-base-compute"
-    - "ohpc-slurm-client"
+    - name: "ohpc-base-compute"
+      install: true
+    - name: "ohpc-slurm-client"
+      install: true
   runtime:
-    - "slurm-ohpc"
-    - "munge"
-    - "slurm-slurmd-ohpc"
-    - "slurm-example-configs-ohpc"
-    - "lmod-ohpc"
+    - name: "slurm-ohpc"
+      install: true
+    - name: "munge"
+      install: true
+    - name: "slurm-slurmd-ohpc"
+      install: true
+    - name: "slurm-example-configs-ohpc"
+      install: true
+    - name: "lmod-ohpc"
+      install: "{{ openhpc_module_system_install }}"
   database:
-    - "slurm-slurmdbd-ohpc"
+    - name: "slurm-slurmdbd-ohpc"
+      install: true
 ...

--- a/vars/ohpc-2
+++ b/vars/ohpc-2
@@ -3,29 +3,18 @@
 
 ohpc_slurm_packages:
   control:
-    - name: "ohpc-slurm-server"
-      install: true
-    - name: "slurm-slurmctld-ohpc"
-      install: true
-    - name: "slurm-example-configs-ohpc"
-      install: true
+    - "ohpc-slurm-server"
+    - "slurm-slurmctld-ohpc"
+    - "slurm-example-configs-ohpc"
   batch:
-    - name: "ohpc-base-compute"
-      install: true
-    - name: "ohpc-slurm-client"
-      install: true
+    - "ohpc-base-compute"
+    - "ohpc-slurm-client"
   runtime:
-    - name: "slurm-ohpc"
-      install: true
-    - name: "munge"
-      install: true
-    - name: "slurm-slurmd-ohpc"
-      install: true
-    - name: "slurm-example-configs-ohpc"
-      install: true
-    - name: "lmod-ohpc"
-      install: "{{ openhpc_module_system_install }}"
+    - "slurm-ohpc"
+    - "munge"
+    - "slurm-slurmd-ohpc"
+    - "slurm-example-configs-ohpc"
+    - "{{ 'lmod-ohpc' if openhpc_module_system_install else '' }}"
   database:
-    - name: "slurm-slurmdbd-ohpc"
-      install: true
+    - "slurm-slurmdbd-ohpc"
 ...


### PR DESCRIPTION
The use case is when you want to use a different module system to the one we supply or want to run without one entirely.