### PR TITLE
Add openhpc_ram_multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ package in the image.
 
 `openhpc_module_system_install`: Optional, default true. Whether or not to install an environment module system. If true, lmod will be installed. If false, You can either supply your own module system or go without one.
 
-`openhpc_ram_multiplier`: Optional, default `0.95`. Multiplier used in the calculation: `total_memory * openhpc_ram_multiplier` when setting `RealMemory` for the partition in slurm.conf. Can be overriden on a per group basis using `openhpc_slurm_partitions.ram_multiplier`
+`openhpc_ram_multiplier`: Optional, default `0.95`. Multiplier used in the calculation: `total_memory * openhpc_ram_multiplier` when setting `RealMemory` for the partition in slurm.conf. Can be overriden on a per partition basis using `openhpc_slurm_partitions.ram_multiplier`. Has no effect if `openhpc_slurm_partitions.ram_mb` is set.
+
 ### slurm.conf
 
 `openhpc_slurm_partitions`: list of one or more slurm partitions.  Each partition may contain the following values:
@@ -53,7 +54,7 @@ package in the image.
   - Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname.
   - Nodes in a group are assumed to be homogenous in terms of processor and memory.
   - An inventory group may be empty, but if it is not then the play must contain at least one node from it (used to set processor information).
-* `ram_multiplier`: Optional, default `openhpc_ram_multiplier`. Allows for per group override of `openhpc_ram_multiplier`. Has no effect if `ram_mb` is set.
+* `ram_multiplier`: Optional.  An override for the top-level definition `openhpc_ram_multiplier`. Has no effect if `ram_mb` is set.
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is
   given by `openhpc_job_maxtime`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ package in the image.
 
 `openhpc_module_system_install`: Optional, default true. Whether or not to install an environment module system. If true, lmod will be installed. If false, You can either supply your own module system or go without one.
 
+`openhpc_ram_multiplier`: Optional, default `0.95`. Multiplier used in the calculation: `total_memory * openhpc_ram_multiplier` when setting `RealMemory` for the partition in slurm.conf. Can be overriden on a per group basis using `openhpc_slurm_partitions.ram_multiplier`
 ### slurm.conf
 
 `openhpc_slurm_partitions`: list of one or more slurm partitions.  Each partition may contain the following values:
@@ -52,7 +53,7 @@ package in the image.
   - Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname.
   - Nodes in a group are assumed to be homogenous in terms of processor and memory.
   - An inventory group may be empty, but if it is not then the play must contain at least one node from it (used to set processor information).
-
+* `ram_multiplier`: Optional, default `openhpc_ram_multiplier`. Allows for per group override of `openhpc_ram_multiplier`. Has no effect if `ram_mb` is set.
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is
   given by `openhpc_job_maxtime`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,3 +52,6 @@ openhpc_slurm_configless: false
 openhpc_munge_key: ''
 openhpc_login_only_nodes: ''
 openhpc_module_system_install: true
+
+# Auto detection
+openhpc_ram_multiplier: 0.95

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -115,7 +115,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
             {% set first_host_hv = hostvars[first_host] %}
 
 NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] }}{% endif %} \
+    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] * (group.ram_multiplier | default(openhpc_ram_multiplier)) }}{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -115,7 +115,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
             {% set first_host_hv = hostvars[first_host] %}
 
 NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] * (group.ram_multiplier | default(openhpc_ram_multiplier)) int }}{% endif %} \
+    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv[('ansible_memory_mb']['real']['total'] * group.ram_multiplier | default(openhpc_ram_multiplier)) | int }}{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -115,7 +115,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
             {% set first_host_hv = hostvars[first_host] %}
 
 NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv[('ansible_memory_mb']['real']['total'] * group.ram_multiplier | default(openhpc_ram_multiplier)) | int }}{% endif %} \
+    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ (first_host_hv['ansible_memory_mb']['real']['total'] * group.ram_multiplier | default(openhpc_ram_multiplier)) | int }}{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -115,7 +115,7 @@ Epilog=/etc/slurm/slurm.epilog.clean
             {% set first_host_hv = hostvars[first_host] %}
 
 NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] * (group.ram_multiplier | default(openhpc_ram_multiplier)) }}{% endif %} \
+    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] * (group.ram_multiplier | default(openhpc_ram_multiplier)) int }}{% endif %} \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}


### PR DESCRIPTION
Using total memory as value of `RealMemory` in slurm.conf does not allow for
OS overheads and can cause slurm to srain the nodes with: `LowRealMemory`.

Fixes #92.