### PR TITLE
Use slurmd's own detection for node definition

### DIFF
--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -43,6 +43,16 @@
   notify:
     - Restart Munge service
 
+- name: Get slurmd's view of node configuration
+  command:
+    cmd: slurmd -C
+  when: openhpc_slurm_service == 'slurmd'
+  register: slurmd_conf
+  changed_when: false
+  # stdout is e.g.:
+  # NodeName=nrel-hpc-0 CPUs=16 Boards=1 SocketsPerBoard=2 CoresPerSocket=8 ThreadsPerCore=1 RealMemory=128616
+  # UpTime=0-00:48:14
+  
 - name: Template slurmdbd.conf
   template:
     src: slurmdbd.conf.j2

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -114,11 +114,8 @@ Epilog=/etc/slurm/slurm.epilog.clean
             {% set first_host = group_hosts | first | mandatory('Group "' + group_name + '" contains no hosts in this play - was --limit used?') %}
             {% set first_host_hv = hostvars[first_host] %}
 
-NodeName=DEFAULT State=UNKNOWN \
-    RealMemory={% if 'ram_mb' in group %}{{group.ram_mb}}{% else %}{{ first_host_hv['ansible_memory_mb']['real']['total'] }}{% endif %} \
-    Sockets={{first_host_hv['ansible_processor_count']}} \
-    CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
-    ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}
+# TODO: support modifying parameters using existing variables
+NodeName=DEFAULT {{ first_host_hv['slurmd_conf'].stdout_lines[0] | regex_replace("NodeName=\S+ ", "") }}
             {% for node in groups[group_name] %}
 NodeName={{ node }}
             {% endfor %}{# nodes #}


### PR DESCRIPTION
Currently the node definitions are constructed using ansible facts. At least in some situations this doesn't appear entirely satisfactory to slurm, e.g. `slurmd -C` shows `... Boards=1 ...` and nodes are getting set DOWN.

This PR runs `slurmd -C` on all compute nodes, then uses values from the first-in-play in each partition (iaw existing logic) to provide node definitions.

This is sort of Trust On First Use that the node configuration is in fact correct.

An alternative is only to specify NodeName and not the expected CPU parameters at all. In that case though slurm will never detect if this config changes.
