### PR TITLE
Fix specification of munge key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ package in the image.
 
 `openhpc_slurm_configless`: Optional, default false. If true then slurm's ["configless" mode](https://slurm.schedmd.com/configless_slurm.html) is used. **NB: Requires Centos8/OpenHPC v2.**
 
-`openhpc_munge_key_path`: Optional, default ''. Define a path for a local file containing a munge key to use, otherwise one will be generated on the slurm control node.
+`openhpc_munge_key`: Optional. Define a munge key to use. If not provided then one is generated but the `openhpc_slurm_control_host` must be in the play.
 
 `openhpc_login_only_nodes`: Optional. If using "configless" mode specify the name of an ansible group containing nodes which are login-only nodes (i.e. not also control nodes), if required. These nodes will run `slurmd` to contact the control node for config.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ openhpc_drain_timeout: 86400
 openhpc_resume_timeout: 300
 openhpc_retry_delay: 10
 openhpc_job_maxtime: 24:00:00
-openhpc_munge_key_path: ''
 
 # Accounting
 openhpc_slurm_accounting_storage_host: "{{ openhpc_slurmdbd_host }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ ohpc_release_repos:
   "7": "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm" # ohpc v1.3 for Centos 7
   "8": "http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm" # ohpc v2 for Centos 8
 openhpc_slurm_configless: false
-openhpc_munge_key: ''
+openhpc_munge_key:
 openhpc_login_only_nodes: ''
 openhpc_module_system_install: true
 

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -14,7 +14,7 @@ test3  | 1            | Y                       | -
 test4  | 1            | N                       | 2x compute node, accounting enabled
 test5  | 1            | N                       | As for #1 but configless
 test6  | 1            | N                       | 0x compute nodes, configless
-test7  | 1            | N                       | 1x compute node, no login node, configless (checks image build should work)
+test7  | 1            | N                       | 1x compute node, no login node so specified munge key, configless (checks image build should work)
 test8  | 1            | N                       | 2x compute node, 2x login-only nodes, configless
 test9  | 1            | N                       | As test8 but uses `--limit=testohpc-control,testohpc-compute-0` and checks login nodes still end up in slurm.conf
 test10 | 1            | N                       | As for #5 but then tries to add an additional node

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -22,13 +22,18 @@ test11 | 1            | N                       | As for #5 but then deletes a n
 
 # Local Installation & Running
 
-Local installation on a Centos7 machine looks like:
+Local installation on a CentOS 8 machine looks like:
 
     sudo yum install -y gcc python3-pip python3-devel openssl-devel python3-libselinux
     sudo yum install -y yum-utils
     sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo yum install -y docker-ce docker-ce-cli containerd.io
-    pip3 install -r molecule/requirements.txt --user
+    sudo yum install -y iptables
+
+    python3 -m venv venv
+    . venv/bin/activate
+    pip install -U pip
+    pip install -r molecule/requirements.txt
 
     sudo systemctl start docker
     sudo usermod -aG docker ${USER}
@@ -45,6 +50,12 @@ Then to run all tests:
     MOLECULE_IMAGE=centos:7 molecule test --all
     MOLECULE_IMAGE=centos:8.2.2004 molecule test --all
 
-Note that to see some debugging information you may want to prepend:
+During development you may want to:
 
-    MOLECULE_NO_LOG="false" ...
+- See some debugging information by prepending:
+
+        MOLECULE_NO_LOG="false" ...
+
+- Prevent destroying insstances using:
+
+        molecule test --destroy never

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,3 +1,4 @@
 pip
 setuptools
 molecule[docker,lint]
+ansible>=2.9.0

--- a/molecule/test1/converge.yml
+++ b/molecule/test1/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test10/converge.yml
+++ b/molecule/test10/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test10/verify.yml
+++ b/molecule/test10/verify.yml
@@ -22,7 +22,7 @@
       run_once: true
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test11/converge.yml
+++ b/molecule/test11/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test11/verify.yml
+++ b/molecule/test11/verify.yml
@@ -19,7 +19,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test1b/converge.yml
+++ b/molecule/test1b/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test1c/converge.yml
+++ b/molecule/test1c/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test2/converge.yml
+++ b/molecule/test2/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test3/converge.yml
+++ b/molecule/test3/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test4/converge.yml
+++ b/molecule/test4/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test5/converge.yml
+++ b/molecule/test5/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test6/converge.yml
+++ b/molecule/test6/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_login'] }}"

--- a/molecule/test7/converge.yml
+++ b/molecule/test7/converge.yml
@@ -2,12 +2,18 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Generate munge key on ansible control host
+    - name: Generate munge key on ansible control host (so can verify)
       command: "dd if=/dev/urandom of=/tmp/ansible-role-openhpc-test7 bs=1 count=1024" # can't use tmpfile as not idempotent
       args:
         creates: "/tmp/ansible-role-openhpc-test7"
       delegate_to: localhost
-      
+
+    - name: Get generated munge key
+      slurp:
+        src: /tmp/ansible-role-openhpc-test7
+      delegate_to: localhost
+      register: specified_munge_key
+
     - name: "Include ansible-role-openhpc"
       include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
@@ -21,5 +27,4 @@
           - name: "compute"
         openhpc_cluster_name: testohpc
         openhpc_slurm_configless: true
-        openhpc_munge_key_path: "/tmp/ansible-role-openhpc-test7"
-
+        openhpc_munge_key: "{{ specified_munge_key.content | b64decode }}"

--- a/molecule/test7/converge.yml
+++ b/molecule/test7/converge.yml
@@ -10,7 +10,7 @@
       
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           batch: true

--- a/molecule/test7/verify.yml
+++ b/molecule/test7/verify.yml
@@ -10,3 +10,23 @@
   - assert:
       that: "'EnvironmentFiles=/etc/sysconfig/slurmd' in systemctl_slurmd.stdout"
       fail_msg: "FAILED - no reference to /etc/sysconfig/slurmd in slurmd config"
+  - name: Get specified munge key
+    slurp:
+      src: /tmp/ansible-role-openhpc-test7
+    register: specified_munge_key
+    delegate_to: localhost
+
+  - name: Get actual munge key
+    slurp:
+      src: /etc/munge/munge.key
+    register: actual_munge_key
+
+  - assert:
+      that: specified_munge_key.content | b64decode == actual_munge_key.content | b64decode
+      fail_msg: |
+        munge key on node does not match specified one:
+        specified:
+        {{ specified_munge_key.content }}
+
+        actual:
+        {{ actual_munge_key.content }}

--- a/molecule/test8/converge.yml
+++ b/molecule/test8/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_control'] }}"

--- a/molecule/test9/converge.yml
+++ b/molecule/test9/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Include ansible-role-openhpc"
       include_role:
-        name: "ansible-role-openhpc/"
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         openhpc_enable:
           control: "{{ inventory_hostname in groups['testohpc_control'] }}"

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -116,7 +116,8 @@
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_enable.database | default(false) | bool
 
-- meta: flush_handlers # as then subsequent "ensure" is a no-op if slurm services bounced
+- name: flush handler
+  meta: flush_handlers # as then subsequent "ensure" is a no-op if slurm services bounced
 
 - name: Ensure Slurm service state
   service:

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -12,6 +12,13 @@
     msg: "openhpc_slurm_configless = True requires Centos8 / OpenHPC v2"
   when: openhpc_slurm_configless and not ansible_distribution_major_version == "8"
 
+- name: Fail if control host not in play and munge key not specified
+  fail:
+    msg: "Either the slurm control node must be in the play or `openhpc_munge_key` must be set"
+  when:
+    - openhpc_slurm_control_host not in ansible_play_hosts
+    - not openhpc_munge_key
+
 - name: Ensure the Slurm spool directory exists
   file:
     path: /var/spool/slurm
@@ -20,22 +27,23 @@
     mode: 0755
     state: directory
 
-- name: Generate a Munge key
+- name: Generate a Munge key on control host
   # NB this is usually a no-op as the package install actually generates a (node-unique) one, so won't usually trigger handler
   command: "dd if=/dev/urandom of=/etc/munge/munge.key bs=1 count=1024"
   args:
     creates: "/etc/munge/munge.key"
   when: inventory_hostname == openhpc_slurm_control_host
 
-- name: Retrieve Munge key
+- name: Retrieve Munge key from control host
   slurp:
-    src: "{{ '/etc/munge/munge.key' if not (openhpc_munge_key_path | default('')) else openhpc_munge_key_path }}"
-  register: openhpc_munge_key
-  delegate_to: "{{ openhpc_slurm_control_host if not (openhpc_munge_key_path | default('')) else 'localhost' }}"
+    src: "/etc/munge/munge.key"
+  register: openhpc_control_munge_key
+  delegate_to: "{{ openhpc_slurm_control_host }}"
+  when: openhpc_slurm_control_host in ansible_play_hosts
 
 - name: Write Munge key
   copy:
-    content: "{{ openhpc_munge_key.content | b64decode }}"
+    content: "{{ openhpc_munge_key or (openhpc_control_munge_key.content | b64decode) }}"
     dest: "/etc/munge/munge.key"
     owner: munge
     group: munge


### PR DESCRIPTION
Currently a munge key can be specified using `openhpc_munge_key_path`. Having the munge key around on the deploy host isn't ideal and isn't compatible with the slurm appliance which expects to be able to set the munge key content directly via a variable. This PR changes to the latter approach as it seems better.

This is slightly tricky to get right as:
- We must support no munge key being provided, but that has to be idempotent (so no use generating a munge key on each run - luckily the slurm package installs actually generate one)
- We have to give an (eventually) consistent munge key across the cluster for three situations:
  - Entire cluster in play
  - Only control node in play
  - Only compute node(s) in play (used for packer build in slurm appliance)

Note first two commits have a wider application.