### PR TITLE
Ensure slurmctld actually up before completing restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,7 +20,7 @@
 
 # NOTE: we need this running before slurmd
 # Allows you to reconfigure slurmctld from another host
-- name: Restart slurmctld service
+- name: Issue slurmctld restart command
   service:
     name: "slurmctld"
     state: restarted
@@ -29,6 +29,18 @@
   when:
     - openhpc_slurm_service_started | bool
     - openhpc_slurm_control_host in play_hosts
+  listen: Restart slurmctld service
+
+- name: Check slurmctld actually restarted
+  wait_for:
+    port: 6817
+    delay: 10
+  delegate_to: "{{ openhpc_slurm_control_host }}"
+  run_once: true
+  when:
+    - openhpc_slurm_service_started | bool
+    - openhpc_slurm_control_host in play_hosts
+  listen: Restart slurmctld service
 
 - name: Restart slurmd service
   service:


### PR DESCRIPTION
At NREL we saw slurm fall over on startup. Hypothesis was that slurmctld startup was taking a while (due slurm.conf taking ~4s to read) but the unit returns immediately. Hence slurmds started and couldn't contact slurmctld, so went down.

Fix checks that slurmctld port is open before exiting the restart handler. 10s delay is to wait for slurmctld to go down. Ran OK on NREL.

 