### PR TITLE
Add centos 8.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         image:
           - 'centos:8.2.2004'
           - 'centos:8.3.2011'
+          - 'centos:8.4.2105'
           - 'centos:7'
         scenario:
           - test1


### PR DESCRIPTION
Note that all CentOS 8.x builds now (since 25 June 2021) get OpenHPC 2.3 ([release notes](https://github.com/openhpc/ohpc/releases/tag/v2.3.GA)). This added support for CentOS8.4