### PR TITLE
CI Workaround: Failed to parse bus message: Invalid argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,16 @@ jobs:
 
   test:
     name: Molecule
-    # Select an image that uses python3 by default
-    runs-on: ubuntu-20.04
+    # Workaround: systemd/kernel compatibility issue:
+    #   Failed to parse bus message: Invalid argument
+    # when doing `systemctl show slurmd` by switching to an older ubuntu
+    # release (18.04 from 20.04). We can remove this when we are running a
+    # systemd version new enough to cope with the extra capabilities that are
+    # in newer kernel versions.
+    # See:
+    #   - https://bugzilla.redhat.com/show_bug.cgi?id=190144
+    #   - https://github.com/systemd/systemd/pull/16424
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
For rationale, please see comment in change.