### PR TITLE
Fix slurm.conf templating

### DIFF
--- a/filter_plugins/group_hosts.py
+++ b/filter_plugins/group_hosts.py
@@ -31,8 +31,27 @@ def _get_hostvar(context, var_name, inventory_hostname=None):
     return namespace.get(var_name)
 
 @jinja2.contextfilter
-def group_hosts(context, group_names):
-    return {g:_group_hosts(context["groups"].get(g, [])) for g in sorted(group_names)}
+def group_hosts(context, group_name):
+    """ Group hostnames in specified inventory group using Slurm's hostlist expression format.
+
+        E.g. with an inventory containing:
+
+            [compute]
+            dev-foo-0 ansible_host=localhost
+            dev-foo-3 ansible_host=localhost
+            my-random-host
+            dev-foo-4 ansible_host=localhost
+            dev-foo-5 ansible_host=localhost
+            dev-compute-0 ansible_host=localhost
+            dev-compute-1 ansible_host=localhost
+
+        This will return:
+            
+            ["dev-foo-[0,3-5]", "dev-compute-[0-1]", "my-random-host"]
+    """
+
+    group = context["groups"].get(group_name, [])
+    return _group_hosts(group)
 
 def _group_hosts(hosts):
     results = {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: openhpc
+  namespace: stackhpc
   author: StackHPC Ltd.
   description: >
     This role provisions an exisiting cluster to support OpenHPC control

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -110,8 +110,8 @@ Epilog=/etc/slurm/slurm.epilog.clean
         {% set group_name = group.cluster_name|default(openhpc_cluster_name) ~ '_' ~ group.name %}
         {% if groups[group_name] | length > 0 %}
             {# If using --limit, the first host in each group may not have facts available. Find one that does, or die: #}
-            {% set group_hosts = groups[group_name] | intersect(play_hosts) %}
-            {% set first_host = group_hosts | first | mandatory('Group "' + group_name + '" contains no hosts in this play - was --limit used?') %}
+            {% set inventory_group_hosts = groups[group_name] | intersect(play_hosts) %}
+            {% set first_host = inventory_group_hosts | first | mandatory('Group "' + group_name + '" contains no hosts in this play - was --limit used?') %}
             {% set first_host_hv = hostvars[first_host] %}
 
 NodeName=DEFAULT State=UNKNOWN \
@@ -119,8 +119,8 @@ NodeName=DEFAULT State=UNKNOWN \
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
     ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}}
-            {% for node in groups[group_name] %}
-NodeName={{ node }}
+            {% for hostlist in (group_name | group_hosts) %}
+NodeName={{ hostlist }}
             {% endfor %}{# nodes #}
         {% else %}
 NodeName=-nonesuch
@@ -133,7 +133,7 @@ PartitionName={{part.name}} \
     Nodes=\
         {% for group in part.get('groups', [part]) %}
             {% set group_name = group.cluster_name|default(openhpc_cluster_name) ~ '_' ~ group.name %}
-            {% if groups[group_name] | length > 0 %}{{ groups[group_name] | join(",\\\n") }}{% if not loop.last %}{{ ",\\\n" }}{% endif %}{% else %}-nonesuch{% endif %}
+            {% if groups[group_name] | length > 0 %}{{ (group_name | group_hosts) | join(",\\\n") }}{% if not loop.last %}{{ ",\\\n" }}{% endif %}{% else %}-nonesuch{% endif %}
         {% endfor %}{# group #}
 {% endfor %}{# partitions #}
 

--- a/tests/filter.yml
+++ b/tests/filter.yml
@@ -3,17 +3,17 @@
   connection: local
   gather_facts: false
   vars:
-    mock_groups:
-      - mock-group-0
-      - mock-group-1
-    grouped_hosts: "{{ mock_groups | group_hosts }}"
+    grouped_0: "{{ 'mock_group_0' | group_hosts }}"
+    grouped_1: "{{ 'mock_group_1' | group_hosts }}"
   tasks:
-    - name: Hosts
-      debug: var=grouped_hosts
+    - name: Show grouped mock-group-0
+      debug: var=grouped_0
+    - name: Show grouped mock-group-1
+      debug: var=grouped_1
     - name: Test filter
       assert:
         that:
-          - "['localhost-0-[0-3,5]', 'localhost-non-numerical'] == grouped_hosts['mock-group-0']"
-          - "['localhost-1-[1-2,4-5,10]', 'localhost-2-[1-3]'] == grouped_hosts['mock-group-1']"
-        msg: "Some assertions did not pass" # alias for fail_msg in 2.7+
+          - "['localhost-0-[0-3,5]', 'localhost-non-numerical'] == grouped_0"
+          - "['localhost-1-[1-2,4-5,10]', 'localhost-2-[1-3]'] == grouped_1"
+
 ...

--- a/tests/inventory-mock-groups
+++ b/tests/inventory-mock-groups
@@ -1,4 +1,4 @@
-[mock-group-0]
+[mock_group_0]
 localhost-0-0 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-0-1 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-0-2 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
@@ -6,7 +6,7 @@ localhost-0-3 ansible_host=127.0.0.1  ansible_connection='local'    ansible_pyth
 localhost-0-5 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-non-numerical ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 
-[mock-group-1]
+[mock_group_1]
 localhost-1-1 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-1-2 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-1-4 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'


### PR DESCRIPTION
This has been getting increasingly complex for a while. This PR will improve this.
- Use slurm hostlist expressions to shorten node enumerations (while maintaining ability to have non-sequential nodenames). This uses a modified version of the currently-unused `group_hosts` filter.