### PR TITLE
Deprecate openhpc_extra_config in favour of openhpc_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ package in the image.
 
 `openhpc_cluster_name`: name of the cluster
 
-`openhpc_extra_config`: Mapping of additional parameters and values for `slurm.conf`. Note these will override any included in `templates/slurm.conf.j2`.
+`openhpc_config`: Mapping of additional parameters and values for `slurm.conf`. Note these will override any included in `templates/slurm.conf.j2`.
 
 `openhpc_state_save_location`: Optional. Absolute path for Slurm controller state (`slurm.conf` parameter [StateSaveLocation](https://slurm.schedmd.com/slurm.conf.html#OPT_StateSaveLocation))
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ openhpc_drain_timeout: 86400
 openhpc_resume_timeout: 300
 openhpc_retry_delay: 10
 openhpc_job_maxtime: 24:00:00
-openhpc_extra_config: {}
+openhpc_config: "{{ openhpc_extra_config | default({}) }}"
 openhpc_state_save_location: /var/spool/slurm
 
 # Accounting

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -20,7 +20,7 @@ test9  | 1            | N                       | As test8 but uses `--limit=tes
 test10 | 1            | N                       | As for #5 but then tries to add an additional node
 test11 | 1            | N                       | As for #5 but then deletes a node (actually changes the partition due to molecule/ansible limitations)
 test12 | 1            | N                       | As for #5 but enabling job completion and testing `sacct -c`
-test13 | 1            | N                       | As for #5 but tests `openhpc_extra_config` variable.
+test13 | 1            | N                       | As for #5 but tests `openhpc_config` variable.
 
 # Local Installation & Running
 

--- a/molecule/test13/converge.yml
+++ b/molecule/test13/converge.yml
@@ -16,6 +16,6 @@
         openhpc_cluster_name: testohpc
         openhpc_slurm_configless: true
         openhpc_login_only_nodes: 'testohpc_login'
-        openhpc_extra_config:
+        openhpc_config:
           FirstJobId: 13
           SlurmctldSyslogDebug: error

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -99,7 +99,7 @@
     no_extra_spaces: true
     create: no
     mode: 0644
-  loop: "{{ openhpc_extra_config | dict2items }}"
+  loop: "{{ openhpc_config | dict2items }}"
   delegate_to: localhost
   when: openhpc_enable.control | default(false) or not openhpc_slurm_configless
   changed_when: false # so molecule doesn't fail

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -140,3 +140,5 @@ PartitionName={{part.name}} \
 # Want nodes that drop out of SLURM's configuration to be automatically
 # returned to service when they come back.
 ReturnToService=2
+
+# Parameters from openhpc_config (which do not override values templated above) will be below here:


### PR DESCRIPTION
To follow kolla pattern better.

This is not currently in use anywhere except the unmerged feature/autoscale branch of the appliance.