### PR TITLE
Enable not defining compute nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - test12
           - test13
           - test14
+          - test15
 
         exclude:
           - image: 'centos:7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             scenario: test13
           - image: 'centos:7'
             scenario: test14
+          - image: 'centos:7'
+            scenario: test15
 
     steps:
       - name: Check out the codebase.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ package in the image.
 For each group (if used) or partition any nodes in an ansible inventory group `<cluster_name>_<group_name>` will be added to the group/partition. Note that:
 - Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname.
 - Nodes in a group are assumed to be homogenous in terms of processor and memory.
-- An inventory group may be empty, but if it is not then the play must contain at least one node from it (used to set processor information).
+- An inventory group may be empty or missing, but if it is not then the play must contain at least one node from it (used to set processor information).
 - Nodes may not appear in more than one group.
-- A group/partition definition which does not have either a corresponding inventory group or a `extra_nodes` will raise an error.
+- At least one partition must be defined, but this done not need to contain any inventory nodes or `extra_nodes`.
 
 `openhpc_job_maxtime`: A maximum time job limit in hours, minutes and seconds.  The default is `24:00:00`.
 

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -51,8 +51,7 @@ Then to run tests, e.g.::
 
     cd ansible-role-openhpc/
     MOLECULE_IMAGE=centos:7 molecule test --all # NB some won't work as require OpenHPC v2.x (-> CentOS 8.x) features - see `.github/workflows/ci.yml`
-    MOLECULE_IMAGE=centos:8.2.2004 molecule test --all
-    MOLECULE_IMAGE=centos:8.3.2011 molecule test --all
+    MOLECULE_IMAGE=rockylinux:8.5 molecule test --all
 
 During development you may want to:
 

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -21,7 +21,8 @@ test10 | 1            | N                       | As for #5 but then tries to ad
 test11 | 1            | N                       | As for #5 but then deletes a node (actually changes the partition due to molecule/ansible limitations)
 test12 | 1            | N                       | As for #5 but enabling job completion and testing `sacct -c`
 test13 | 1            | N                       | As for #5 but tests `openhpc_config` variable.
-test14 | 1            |                         | As for #5 but also tests `extra_nodes` via State=DOWN nodes.
+test14 | 1            | N                       | As for #5 but also tests `extra_nodes` via State=DOWN nodes.
+test15 | 1            | N                       | No compute nodes.
 
 # Local Installation & Running
 
@@ -52,6 +53,8 @@ Then to run tests, e.g.::
     cd ansible-role-openhpc/
     MOLECULE_IMAGE=centos:7 molecule test --all # NB some won't work as require OpenHPC v2.x (-> CentOS 8.x) features - see `.github/workflows/ci.yml`
     MOLECULE_IMAGE=rockylinux:8.5 molecule test --all
+
+**NB:** If the host network has an MTU smaller than 1500 (the docker default), check `molecule.yml` for the relevant test contains `DOCKER_MTU`, then prepend `DOCKER_MTU=<mtu>` to your command. If you have already run molecule you will need to destroy the instances and run `docker network prune` before retrying.
 
 During development you may want to:
 

--- a/molecule/test15/converge.yml
+++ b/molecule/test15/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-openhpc"
+      include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        openhpc_enable:
+          control: "{{ inventory_hostname in groups['testohpc_control'] }}"
+          batch: false
+          runtime: true
+        openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
+        openhpc_slurm_partitions: []
+        openhpc_cluster_name: testohpc
+        openhpc_slurm_configless: true
+

--- a/molecule/test15/converge.yml
+++ b/molecule/test15/converge.yml
@@ -11,7 +11,8 @@
           batch: false
           runtime: true
         openhpc_slurm_control_host: "{{ groups['testohpc_control'] | first }}"
-        openhpc_slurm_partitions: []
+        openhpc_slurm_partitions:
+          - name: n/a
         openhpc_cluster_name: testohpc
         openhpc_slurm_configless: true
 

--- a/molecule/test15/molecule.yml
+++ b/molecule/test15/molecule.yml
@@ -1,0 +1,26 @@
+---
+name: single partition, group is partition
+driver:
+  name: docker
+platforms:
+  - name: testohpc-control
+    image: ${MOLECULE_IMAGE}
+    pre_build_image: true
+    groups:
+      - testohpc_control
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: net1
+    docker_networks:
+      - name: net1
+        driver_options:
+          com.docker.network.driver.mtu: ${DOCKER_MTU:-1500} # 1500 is docker default
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/test15/verify.yml
+++ b/molecule/test15/verify.yml
@@ -8,5 +8,5 @@
     register: sinfo
   - name: 
     assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
-      that: "sinfo.stdout_lines == ['n/a,up,infinite,0,n/a,']"
+      that: "sinfo.stdout_lines == ['n/a*,up,60-00:00:00,0,n/a,']"
       fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/molecule/test15/verify.yml
+++ b/molecule/test15/verify.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Check slurm hostlist
+  hosts: testohpc_control
+  tasks:
+  - name: Get slurm partition info
+    command: sinfo --noheader --format="%P,%a,%l,%D,%t,%N" # using --format ensures we control whitespace
+    register: sinfo
+  - name: 
+    assert:                        # PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+      that: "sinfo.stdout_lines == ['n/a,up,infinite,0,n/a,']"
+      fail_msg: "FAILED - actual value: {{ sinfo.stdout_lines }}"

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -1,11 +1,11 @@
 ---
-- name: Fail if openhpc_cluster_name is undefined
-  # removed tests on openhpc_slurm_partitions and openhpc_slurm_control_host as both have role defaults which passed tests
-  assert:
-    that:
-      - openhpc_cluster_name is defined
-      - openhpc_cluster_name != none
-    fail_msg: "'openhpc_cluster_name' is not defined."
+- name: Fail if openhpc_slurm_control_host or openhpc_cluster_name or openhpc_slurm_partitions are undefined
+  fail:
+    msg: "Undefined openhpc_slurm_control_host or openhpc_cluster_name or openhpc_slurm_partitions, or latter is empty."
+  when:
+    openhpc_slurm_control_host == none or
+    openhpc_cluster_name == none or
+    openhpc_slurm_partitions | length == 0
 
 - name: Fail if configless mode selected when not on Centos 8
   fail:

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -1,11 +1,11 @@
 ---
-- name: Fail if openhpc_slurm_control_host or openhpc_cluster_name or openhpc_slurm_partitions are undefined
-  fail:
-    msg: "Undefined openhpc_slurm_control_host or openhpc_cluster_name or openhpc_slurm_partitions, or latter is empty."
-  when:
-    openhpc_slurm_control_host == none or
-    openhpc_cluster_name == none or
-    openhpc_slurm_partitions | length == 0
+- name: Fail if openhpc_cluster_name is undefined
+  # removed tests on openhpc_slurm_partitions and openhpc_slurm_control_host as both have role defaults which passed tests
+  assert:
+    that:
+      - openhpc_cluster_name is defined
+      - openhpc_cluster_name != none
+    fail_msg: "'openhpc_cluster_name' is not defined."
 
 - name: Fail if configless mode selected when not on Centos 8
   fail:

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -128,11 +128,15 @@ NodeName={{ hostlist }} State=UNKNOWN RealMemory={{ group.get('ram_mb', ram_mb) 
         {% endfor %}
     {% endfor %}{# group #}
 {% if not nodelist %}  {# empty partition - define an invalid hostname which slurm accepts #}
-    {% set nodelist = ['-nonesuch'] %}
+    {% set nodelist = ['n/a'] %}
 NodeName={{ nodelist[0] }}
 {% endif %}
 PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }}
 {% endfor %}{# partitions #}
+{% if openhpc_slurm_partitions | length == 0 %}{# define some clearly invalid things which slurm accepts #}
+NodeName=n/a
+PartitionName= n/a
+{% endif %}
 
 # Want nodes that drop out of SLURM's configuration to be automatically
 # returned to service when they come back.

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -133,10 +133,6 @@ NodeName={{ nodelist[0] }}
 {% endif %}
 PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }}
 {% endfor %}{# partitions #}
-{% if openhpc_slurm_partitions | length == 0 %}{# define some clearly invalid things which slurm accepts #}
-NodeName=n/a
-PartitionName= n/a
-{% endif %}
 
 # Want nodes that drop out of SLURM's configuration to be automatically
 # returned to service when they come back.


### PR DESCRIPTION
Want to be able not to define compute nodes, so that we can build a control image alone in the slurm appliance.