### PR TITLE
Add wait_for slurmdbd port

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
   when: openhpc_slurm_service_started | bool
 
 # NOTE: we need this running before slurmctld start
-- name: Restart slurmdbd service
+- name: Issue slurmdbd restart command
   service:
     name: "slurmdbd"
     state: restarted
@@ -17,6 +17,7 @@
     - openhpc_slurm_service_started | bool
     - openhpc_slurmdbd_host in play_hosts
   run_once: true
+  listen: Restart slurmdbd service
 
 - name: Check slurmdbd actually restarted
   wait_for:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,6 +18,17 @@
     - openhpc_slurmdbd_host in play_hosts
   run_once: true
 
+- name: Check slurmdbd actually restarted
+  wait_for:
+    port: "{{ openhpc_slurmdbd_port }}"
+  delegate_to: "{{ openhpc_slurmdbd_host }}"
+  run_once: true
+  when:
+    - openhpc_slurmdbd_host is defined
+    - openhpc_slurm_service_started | bool
+    - openhpc_slurmdbd_host in play_hosts
+  listen: Restart slurmdbd service
+
 # NOTE: we need this running before slurmd
 # Allows you to reconfigure slurmctld from another host
 - name: Issue slurmctld restart command

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -163,15 +163,15 @@
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
 
+- name: flush handler
+  meta: flush_handlers # as then subsequent "ensure" is a no-op if slurm services bounced
+
 - name: Ensure slurmdbd is started and running
   service:
     name: slurmdbd
     enabled: "{{ openhpc_slurm_service_enabled | bool }}"
     state: "{{ 'started' if openhpc_slurm_service_started | bool else 'stopped' }}"
   when: openhpc_enable.database | default(false) | bool
-
-- name: flush handler
-  meta: flush_handlers # as then subsequent "ensure" is a no-op if slurm services bounced
 
 - name: Ensure Slurm service state
   service:


### PR DESCRIPTION
Ensure that the slurmdbd service is accessible on its specified port after a restart before restarting any other services that
might depend on slurmdbd being accessible.

This fixes an issue where `slurmctld` is raised before `slurmdbd` is responding on its port, causing `systemctl restart slurmctld` to fail with the following message to syslog:

```
Mar  3 17:02:58 matt-slurm-control-0 slurmctld[63748]: accounting_storage/slurmdbd: clusteracct_storage_p_register_ctld: Registering slurmctld at port 6817 with slurmdbd
Mar  3 17:02:58 matt-slurm-control-0 slurmctld[63748]: error: Sending PersistInit msg: Connection refused
Mar  3 17:02:58 matt-slurm-control-0 slurmctld[63748]: fatal: You are running with a database but for some reason we have no TRES from it.  This should only happen if the database is down and you don't have any state files.
Mar  3 17:02:58 matt-slurm-control-0 systemd[1]: slurmctld.service: Main process exited, code=exited, status=1/FAILURE
Mar  3 17:02:58 matt-slurm-control-0 systemd[1]: slurmctld.service: Failed with result 'exit-code'.
```

This `wait_for` approach is already taken when restarting the `slurmctld` daemon. 