### PR TITLE
Support defining any partition parameters

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
 skip_list:
   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern'
+  - 'fqcn-builtins'

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ package in the image.
 * `default`: Optional.  A boolean flag for whether this partion is the default.  Valid settings are `YES` and `NO`.
 * `maxtime`: Optional.  A partition-specific time limit in hours, minutes and seconds ([slurm.conf](https://slurm.schedmd.com/slurm.conf.html) parameter `MaxTime`).  The default value is
   given by `openhpc_job_maxtime`.
+* `partition_params`: Optional. Mapping of additional parameters and values for [partition configuration](https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION).
 
 For each group (if used) or partition any nodes in an ansible inventory group `<cluster_name>_<group_name>` will be added to the group/partition. Note that:
 - Nodes may have arbitrary hostnames but these should be lowercase to avoid a mismatch between inventory and actual hostname.
@@ -64,7 +65,7 @@ For each group (if used) or partition any nodes in an ansible inventory group `<
 
 `openhpc_cluster_name`: name of the cluster
 
-`openhpc_config`: Mapping of additional parameters and values for `slurm.conf`. Note these will override any included in `templates/slurm.conf.j2`.
+`openhpc_config`: Optional. Mapping of additional parameters and values for `slurm.conf`. Note these will override any included in `templates/slurm.conf.j2`.
 
 `openhpc_ram_multiplier`: Optional, default `0.95`. Multiplier used in the calculation: `total_memory * openhpc_ram_multiplier` when setting `RealMemory` for the partition in slurm.conf. Can be overriden on a per partition basis using `openhpc_slurm_partitions.ram_multiplier`. Has no effect if `openhpc_slurm_partitions.ram_mb` is set.
 

--- a/filter_plugins/slurm_conf.py
+++ b/filter_plugins/slurm_conf.py
@@ -80,10 +80,16 @@ def error(condition, msg):
     if not condition:
         raise errors.AnsibleFilterError(msg)
 
+def dict2parameters(d):
+    """ Convert a dict into a str in 'k1=v1 k2=v2 ...' format """
+    parts = ['%s=%s' % (k, v) for k, v in d.items()]
+    return ' '.join(parts)
+
 class FilterModule(object):
 
     def filters(self):
         return {
             'hostlist_expression': hostlist_expression,
             'error': error,
+            'dict2parameters': dict2parameters,
         }

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -131,7 +131,7 @@ NodeName={{ hostlist }} State=UNKNOWN RealMemory={{ group.get('ram_mb', ram_mb) 
     {% set nodelist = ['-nonesuch'] %}
 NodeName={{ nodelist[0] }}
 {% endif %}
-PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }}
+PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }} {{ part.partition_params | default({}) | dict2parameters }}
 {% endfor %}{# partitions #}
 
 # Want nodes that drop out of SLURM's configuration to be automatically


### PR DESCRIPTION
Adds a new `partition_params` option to partition definition which is just passed through to Slurm, allowing user to specify any partition configuration desired.

I had considered using arbitrary keys directly in the partition definition, but this is hard to achieve as the [rebuild role](https://github.com/stackhpc/ansible_collection_slurm_openstack_tools/tree/main/roles/autoscale) modifies what is acceptable in the partition dict. So either the `autoscale` role would have to strip out the extras again, which means hostvars change during a play, or this role would have to be aware of what that `autoscale` role supports. Seems nicer to just provide a separate dict.