### PR TITLE
Improve empty partition name

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -128,7 +128,7 @@ NodeName={{ hostlist }} State=UNKNOWN RealMemory={{ group.get('ram_mb', ram_mb) 
         {% endfor %}
     {% endfor %}{# group #}
 {% if not nodelist %}  {# empty partition - define an invalid hostname which slurm accepts #}
-    {% set nodelist = ['-nonesuch'] %}
+    {% set nodelist = ['n/a'] %}
 NodeName={{ nodelist[0] }}
 {% endif %}
 PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }} {{ part.partition_params | default({}) | dict2parameters }}


### PR DESCRIPTION
Being able to define empty partitions is useful but a [bit difficult](https://lists.schedmd.com/pipermail/slurm-users/2020-December/006563.html). The current approach looks really ugly, this PR makes `sinfo` output show e.g. 

```
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
hpc*         up   infinite      0    n/a
```

which looks more intuitive to the user.