### PR TITLE
Improve openhpc_state_save_location templating

### DIFF
--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -21,12 +21,12 @@
 
 - name: Ensure Slurm directories exists
   file:
-    path: "{{ item }}"
+    path: "{{ openhpc_state_save_location }}"
     owner: slurm
     group: slurm
     mode: 0755
     state: directory
-  loop: "{{ ['/var/spool/slurm'] + ([ openhpc_state_save_location ] if inventory_hostname == openhpc_slurm_control_host else []) }}"
+  when: inventory_hostname == openhpc_slurm_control_host
 
 - name: Generate a Munge key on control host
   # NB this is usually a no-op as the package install actually generates a (node-unique) one, so won't usually trigger handler


### PR DESCRIPTION
This role provides `openhpc_state_save_location` to allow slurmctld state being moved from its default location. However the current templating requires this to be defined/templatable for all hosts. With https://github.com/stackhpc/ansible-slurm-appliance/pull/173 that is unlikely to be the case, so this relaxes this restriction.