### PR TITLE
Fix slurm.conf inventory filtering for nodenames with padding

### DIFF
--- a/filter_plugins/slurm_conf.py
+++ b/filter_plugins/slurm_conf.py
@@ -18,7 +18,6 @@
 from ansible import errors
 import jinja2
 import re
-import pprint
 
 # Pattern to match a hostname with numerical ending
 pattern = re.compile("^(.*\D(?=\d))(\d+)$")

--- a/filter_plugins/slurm_conf.py
+++ b/filter_plugins/slurm_conf.py
@@ -38,17 +38,17 @@ def hostlist_expression(hosts):
         E.g. with an inventory containing:
 
             [compute]
-            dev-foo-0 ansible_host=localhost
-            dev-foo-3 ansible_host=localhost
+            dev-foo-00 ansible_host=localhost
+            dev-foo-3  ansible_host=localhost
             my-random-host
-            dev-foo-4 ansible_host=localhost
-            dev-foo-5 ansible_host=localhost
-            dev-compute-0 ansible_host=localhost
-            dev-compute-1 ansible_host=localhost
+            dev-foo-04 ansible_host=localhost
+            dev-foo-05 ansible_host=localhost
+            dev-compute-000 ansible_host=localhost
+            dev-compute-001 ansible_host=localhost
 
         Then "{{ groups[compute] | hostlist_expression }}" will return:
             
-            ["dev-foo-[0,3-5]", "dev-compute-[0-1]", "my-random-host"]
+            ['dev-foo-[00,04-05,3]', 'dev-compute-[000-001]', 'my-random-host']
     """
 
     results = {}
@@ -57,21 +57,24 @@ def hostlist_expression(hosts):
         m = pattern.match(v)
         if m:
             prefix, suffix = m.groups()
+            print(prefix,suffix)
             r = results.setdefault(prefix, [])
-            r.append(int(suffix))
+            r.append(suffix)
         else:
             unmatchable.append(v)
     return ['{}[{}]'.format(k, _group_numbers(v)) for k, v in results.items()] + unmatchable
 
 def _group_numbers(numbers):
+    print('numbers:', sorted(numbers))
     units = []
-    prev = min(numbers)
+    prev = min(int(n) for n in numbers)
     for v in sorted(numbers):
-        if v == prev + 1:
+        if int(v) == prev + 1:
             units[-1].append(v)
         else:
             units.append([v])
-        prev = v
+        print('units:', units)
+        prev = int(v)
     return ','.join(['{}-{}'.format(u[0], u[-1]) if len(u) > 1 else str(u[0]) for u in units])
 
 def error(condition, msg):

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -26,7 +26,7 @@ test15 | 1            | N                       | No compute nodes.
 
 # Local Installation & Running
 
-Local installation on a CentOS 8 machine looks like:
+Local installation on a RockyLinux 8.x machine looks like:
 
     sudo yum install -y gcc python3-pip python3-devel openssl-devel python3-libselinux
     sudo yum install -y yum-utils
@@ -35,8 +35,7 @@ Local installation on a CentOS 8 machine looks like:
     sudo yum install -y iptables
     sudo systemctl start docker
     sudo usermod -aG docker ${USER}
-    # if not running as centos, also run:
-    sudo usermod -aG docker centos
+    sudo usermod -aG docker rocky
     newgrp docker
     docker run hello-world # test docker works without sudo
 

--- a/molecule/test12/molecule.yml
+++ b/molecule/test12/molecule.yml
@@ -16,6 +16,10 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: net1
+    docker_networks:
+      - name: net1
+        driver_options:
+          com.docker.network.driver.mtu: ${DOCKER_MTU:-1500} # 1500 is docker default
   - name: testohpc-compute-0
     image: ${MOLECULE_IMAGE}
     pre_build_image: true

--- a/molecule/test12/verify.yml
+++ b/molecule/test12/verify.yml
@@ -23,6 +23,9 @@
       cmd: "sacct --completion --noheader --parsable2"
     changed_when: false
     register: sacct
+    until: "sacct.stdout.strip() != ''"
+    retries: 5
+    delay: 1
   - assert:
       that: "(jobid + '|0|wrap|compute|2|testohpc-compute-[0-1]|COMPLETED') in sacct.stdout"
       fail_msg: "Didn't find expected output for {{ jobid }} in sacct output: {{ sacct.stdout }}"

--- a/tests/filter.yml
+++ b/tests/filter.yml
@@ -5,15 +5,19 @@
   vars:
     grouped_0: "{{ groups['mock_group_0'] | hostlist_expression }}"
     grouped_1: "{{ groups['mock_group_1'] | hostlist_expression }}"
+    grouped_2: "{{ groups['mock_group_2'] | hostlist_expression }}"
   tasks:
-    - name: Show grouped mock-group-0
-      debug: var=grouped_0
-    - name: Show grouped mock-group-1
-      debug: var=grouped_1
     - name: Test filter
       assert:
-        that:
-          - "['localhost-0-[0-3,5]', 'localhost-non-numerical'] == grouped_0"
-          - "['localhost-1-[1-2,4-5,10]', 'localhost-2-[1-3]'] == grouped_1"
-
+        that: item.result == item.expected
+        fail_msg: |
+          expected: {{ item.expected }}
+          got: {{ item.result }}
+      loop:
+        - result: "{{ grouped_0 }}"
+          expected: ['localhost-0-[0-3,5]', 'localhost-non-numerical']
+        - result: "{{ grouped_1 }}"
+          expected: ['localhost-1-[1-2,4-5,10]', 'localhost-2-[1-3]']
+        - result: "{{ grouped_2 }}"
+          expected: ['localhost-[1,0001-0003,0008,0010]', 'localhost-admin']
 ...

--- a/tests/inventory-mock-groups
+++ b/tests/inventory-mock-groups
@@ -15,3 +15,15 @@ localhost-1-10 ansible_host=127.0.0.1  ansible_connection='local'    ansible_pyt
 localhost-2-1 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-2-2 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
 localhost-2-3 ansible_host=127.0.0.1  ansible_connection='local'    ansible_python_interpreter='/usr/bin/env python'
+
+[mock_group_2]
+# test padding:
+# $ scontrol show hostlist localhost-admin,localhost-0001,localhost-0002,localhost-0003,localhost-0008,localhost-0010,localhost-1
+# localhost-admin,localhost-[0001-0003,0008,0010,1]
+localhost-0001
+localhost-1
+localhost-0010
+localhost-admin
+localhost-0002
+localhost-0008
+localhost-0003


### PR DESCRIPTION
The `hostlist_expression` filter is used to convert a list of hostnames from an inventory group into a nice short slurm hostlist expression IF those hosts have a numerical suffix. However currently it doesn't cope with padding, e.g. `[compute-001, compute-002]` gets converted into `compute-[0-2]` which breaks slurm (as those aren't actually the hostnames).

This PR fixes this and copes even with a pretty pathological case (see example in docstring below).