### PR TITLE
Make munge daemon start depend on cloud-init final finishing

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,6 +46,22 @@
     name: "{{ openhpc_slurm_pkglist | reject('eq', '') }}"
   when: openhpc_slurm_pkglist | default(false, true)
 
+- name: Create drop-in directory for munge service
+  ansible.builtin.file:
+    path: /etc/systemd/system/munge.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Delay munge start till after cloud-init
+  # in case mungekey is injected by cloud-init
+  copy:
+    dest: /etc/systemd/system/munge.service.d/slurmapp.conf
+    content: |
+      [Unit]
+      After=cloud-final.service
+
 - name: Install packages from openhpc_packages variable
   yum:
     name: "{{ openhpc_packages }}"


### PR DESCRIPTION
This allows cloud-init to inject the munge key, if desired. Without this a munge startup failure occurs complaining the munge key does not have enough bytes.