### PR TITLE
Fix CI for molecule v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install -U ansible molecule[podman] yamllint ansible-lint
+          pip3 install -U ansible molecule-podman yamllint ansible-lint
           ansible-galaxy collection install containers.podman:>=1.10.1 # otherwise get https://github.com/containers/ansible-podman-collections/issues/428
 
       - name: Display ansible version


### PR DESCRIPTION
Podman driver install has changed with molecule v5 release.

Runs on current main code:
- working on molecule v4 https://github.com/stackhpc/ansible-role-openhpc/actions/runs/4732740113/jobs/8399283702
- failing on molecule v5: https://github.com/stackhpc/ansible-role-openhpc/actions/runs/4732740113/jobs/8529894422