### PR TITLE
Allow multiple empty partitions

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -129,9 +129,8 @@ NodeName={{ hostlist }} State=UNKNOWN RealMemory={{ group.get('ram_mb', ram_mb) 
             {% set _ = nodelist.append(extra_node_defn['NodeName']) %}
         {% endfor %}
     {% endfor %}{# group #}
-{% if not nodelist %}  {# empty partition - define an invalid hostname which slurm accepts #}
-    {% set nodelist = ['n/a'] %}
-NodeName={{ nodelist[0] }}
+{% if not nodelist %}  {# empty partition #}
+    {% set nodelist = ['""'] %}
 {% endif %}
 PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ part.get('maxtime', openhpc_job_maxtime) }} State=UP Nodes={{ nodelist | join(',') }} {{ part.partition_params | default({}) | dict2parameters }}
 {% endfor %}{# partitions #}


### PR DESCRIPTION
Allows multiple partitions defined in `openhpc_slurm_partitions` to have no nodes in the appropriate group.

Currently for this case slurm.conf ends up with
```
NodeName=n/a
```

for *each* empty partition, which fails for multiple such partitions:
```
control slurmctld[102929]: fatal: Duplicated NodeHostName n/a in config file
```

The fix is to not define the node (`NodeName`) line and generate a partition definition like:
```
PartitionName=whatever ... Nodes=""
```

Note this isn't quite as [per docs](https://slurm.schedmd.com/slurm.conf.html#OPT_Nodes_1) but appears a plausible docs typo - see prior discussion [here](https://groups.google.com/g/slurm-users/c/YzPoA4jbTp0).