### PR TITLE
Bump CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     # See:
     #   - https://bugzilla.redhat.com/show_bug.cgi?id=190144
     #   - https://github.com/systemd/systemd/pull/16424
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,8 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install -U ansible molecule-podman yamllint ansible-lint
+          pip3 install -U pip
+          pip3 install -U -r molecule/requirements.txt
           ansible-galaxy collection install containers.podman:>=1.10.1 # otherwise get https://github.com/containers/ansible-podman-collections/issues/428
 
       - name: Display ansible version

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -32,7 +32,7 @@ Local installation on a RockyLinux 8.x machine looks like:
     sudo yum install -y git
     git clone git@github.com:stackhpc/ansible-role-openhpc.git
     cd ansible-role-openhpc/
-    python3.8 -m venv venv
+    python3.9 -m venv venv
     . venv/bin/activate
     pip install -U pip
     pip install -r molecule/requirements.txt
@@ -50,7 +50,7 @@ During development you may want to:
 
 - See some debugging information by prepending:
 
-        MOLECULE_NO_LOG="false" ...
+        MOLECULE_NO_LOG=false ...
 
 - Prevent destroying insstances using:
 

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,3 @@
-pip
-setuptools
-molecule[podman,lint,ansible]
-ansible>=2.9.0
+molecule==5.0.1
+ansible==7.5.0
+molecule-plugins[podman]==23.4.1


### PR DESCRIPTION
Bump versions of image/tools used in CI, and make the local molecule install the same as CI.

Note the `molecule-podman` package is now archived, and the [docs say](https://molecule.readthedocs.io/installation/#install) to use `molecule-plugins[podman]` instead.