### PR TITLE
Add openhpc_slurm_control_host_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ each list element:
 
 `openhpc_slurm_service_started`: Optional boolean. Whether to start slurm services. If set to false, all services will be stopped. Defaults to `openhpc_slurm_service_enabled`.
 
-`openhpc_slurm_control_host`: ansible host name of the controller e.g `"{{ groups['cluster_control'] | first }}"`.
+`openhpc_slurm_control_host`: Required string. Ansible inventory hostname (and short hostname) of the controller e.g. `"{{ groups['cluster_control'] | first }}"`.
+
+`openhpc_slurm_control_host_address`: Optional string. IP address or name to use for the `openhpc_slurm_control_host`, e.g. to use a different interface than is resolved from `openhpc_slurm_control_host`.
 
 `openhpc_packages`: additional OpenHPC packages to install.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ openhpc_slurm_service_enabled: true
 openhpc_slurm_service_started: "{{ openhpc_slurm_service_enabled }}"
 openhpc_slurm_service:
 openhpc_slurm_control_host: "{{ inventory_hostname }}"
+#openhpc_slurm_control_host_address:
 openhpc_slurm_partitions: []
 openhpc_cluster_name:
 openhpc_packages:

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -156,7 +156,7 @@
 - name: Set slurmctld location for configless operation
   lineinfile:
     path: /etc/sysconfig/slurmd
-    line: "SLURMD_OPTIONS='--conf-server {{ openhpc_slurm_control_host }}'"
+    line: "SLURMD_OPTIONS='--conf-server {{ openhpc_slurm_control_host_address | default(openhpc_slurm_control_host) }}'"
     regexp: "^SLURMD_OPTIONS="
     create: yes
     owner: root

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -9,10 +9,7 @@
 # See the slurm.conf man page for more information.
 #
 ClusterName={{ openhpc_cluster_name }}
-ControlMachine={{ openhpc_slurm_control_host }}
-#ControlAddr=
-#BackupController=
-#BackupAddr=
+SlurmctldHost={{ openhpc_slurm_control_host }}{% if openhpc_slurm_control_host_address is defined %}({{ openhpc_slurm_control_host_address }}){% endif %}
 #
 SlurmUser=slurm
 #SlurmdUser=root


### PR DESCRIPTION
Adds a new variable `openhpc_slurm_control_host_address` to allow the address for slurmctld to be specified, e.g. to allow using a different interface than the one `openhpc_slurm_control_host` resolves to.

Also clarifies documentation on `openhpc_slurm_control_host_address` and removes related deprecated variables in `slurm.conf`.