### PR TITLE
Fix singularity/apptainer clash

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,7 @@
 - name: Install required slurm packages
   yum:
     name: "{{ openhpc_slurm_pkglist | reject('eq', '') }}"
+    install_weak_deps: false
   when: openhpc_slurm_pkglist | default(false, true)
 
 - name: Install packages from openhpc_packages variable


### PR DESCRIPTION
Prevent install of "weak dependencies" of openhpc packages. This avoids a dependency clash between `singularity-ce` (which was installed as a [recommendation of the openhpc-base-compute package](https://github.com/openhpc/ohpc/blob/79bce41f519a900c5c8f97e6aceaed0d656c45e0/components/admin/meta-packages/SPECS/meta-packages.spec#L96) and `apptainer`. Presumably this is occuring now due to updates to singularity-ce/apptainer dependencies.

Note systems will now only have apptainer, not also `singularity-ce`.

Error was:
```    openstack.openhpc: TASK [stackhpc.openhpc : Install packages from openhpc_packages variable] ******
    openstack.openhpc: task path: /home/runner/work/ansible-slurm-appliance/ansible-slurm-appliance/ansible/roles/stackhpc.openhpc/tasks/install.yml:48
    openstack.openhpc: fatal: [default]: FAILED! => {
    openstack.openhpc:     "changed": false,
    openstack.openhpc:     "failures": [],
    openstack.openhpc:     "rc": 1,
    openstack.openhpc:     "results": []
    openstack.openhpc: }
    openstack.openhpc: 
    openstack.openhpc: MSG:
    openstack.openhpc: 
    openstack.openhpc: Depsolve Error occurred: 
    openstack.openhpc:  Problem: problem with installed package singularity-ce-3.11.5-1.el8.x86_64
    openstack.openhpc:   - package singularity-ce-3.11.5-1.el8.x86_64 conflicts with sif-runtime provided by apptainer-1.2.4-1.el8.x86_64
    openstack.openhpc:   - package apptainer-1.2.4-1.el8.x86_64 conflicts with sif-runtime provided by singularity-ce-3.11.5-1.el8.x86_64
    openstack.openhpc:   - conflicting requests
```

See https://github.com/openhpc/ohpc/issues/1889 for additional discussion.