### PR TITLE
Build RL9.3 container images with systemd in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,33 @@ name: CI
       - master
 
 jobs:
+  build:
+    name: Build Rocky9 container image
+    # Upstream rockylinux:9.3 images don't contain systemd, which means /sbin/init fails.
+    # A workaround of using "/bin/bash -c 'dnf -y install systemd && /sbin/init'"
+    # as the container command is flaky.
+    # This job builds an image using the upstream rockylinux:9.3 image which ensures
+    # that the image used for the molecule workflow is always updated.
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: molecule/images
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: podman build -t rocky93systemd:latest .
+
+      - name: Save image
+        run: podman save --output rocky93systemd.docker rocky93systemd:latest
+
+      - name: Upload rocky9 image
+        uses: actions/upload-artifact@v4
+        with:
+          name: rocky93systemd
+          path: molecule/images/rocky93systemd.docker
+    
   molecule:
     name: Molecule
     # Workaround: systemd/kernel compatibility issue:
@@ -18,13 +45,14 @@ jobs:
     # See:
     #   - https://bugzilla.redhat.com/show_bug.cgi?id=190144
     #   - https://github.com/systemd/systemd/pull/16424
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    needs: build
     strategy:
       fail-fast: false
       matrix:
         image:
           - 'rockylinux:8.9'
-          - 'rockylinux:9.3'
+          - 'localhost/rocky93systemd'
         scenario:
           - test1
           - test1b
@@ -42,12 +70,23 @@ jobs:
           - test12
           - test13
           - test14
-
         exclude: []
 
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
+
+      - name: Download rocky9 container image
+        uses: actions/download-artifact@v4
+        with:
+          name: rocky93systemd
+          path: molecule/images/rocky93systemd.docker
+        if: matrix.image == 'localhost/rocky93systemd'
+
+      - name: Load rocky9 container image
+        run: podman load --input rocky93systemd.docker/rocky93systemd.docker
+        working-directory: molecule/images
+        if: matrix.image == 'localhost/rocky93systemd'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,6 @@ jobs:
     
   molecule:
     name: Molecule
-    # Workaround: systemd/kernel compatibility issue:
-    #   Failed to parse bus message: Invalid argument
-    # when doing `systemctl show slurmd` by switching to an older ubuntu
-    # release (18.04 from 20.04). We can remove this when we are running a
-    # systemd version new enough to cope with the extra capabilities that are
-    # in newer kernel versions.
-    # See:
-    #   - https://bugzilla.redhat.com/show_bug.cgi?id=190144
-    #   - https://github.com/systemd/systemd/pull/16424
     runs-on: ubuntu-22.04
     needs: build
     strategy:

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -39,17 +39,18 @@ Local installation on a RockyLinux 8.x machine looks like:
     pip install -r molecule/requirements.txt
     ansible-galaxy collection install containers.podman:>=1.10.1
 
-Then to run tests, e.g.::
+Build a RockyLinux 9.3 image with systemd included:
+
+    cd ansible-role-openhpc/molecule/images
+    podman build -t rocky93systemd:latest .
+
+Run tests, e.g.:
 
     cd ansible-role-openhpc/
-    MOLECULE_IMAGE=rockylinux:8.9 molecule test --all
+    MOLECULE_NO_LOG="false" MOLECULE_IMAGE=rockylinux:8.9 molecule test --all
 
-During development you may want to:
+where the image may be `rockylinux:8.9` or `localhost/rocky93systemd`.
 
-- See some debugging information by prepending:
-
-        MOLECULE_NO_LOG="false" ...
-
-- Prevent destroying insstances using:
-
-        molecule test --destroy never
+Other useful options during development:
+- Prevent destroying instances by using `molecule test --destroy never`
+- Run only a single test using e.g. `molecule test --scenario test5`

--- a/molecule/images/Dockerfile
+++ b/molecule/images/Dockerfile
@@ -1,0 +1,2 @@
+FROM rockylinux:9.3
+RUN dnf install -y systemd && dnf clean all

--- a/molecule/test1/molecule.yml
+++ b/molecule/test1/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test10/molecule.yml
+++ b/molecule/test10/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     groups:
       - testohpc_login
       - initial
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -21,7 +21,7 @@ platforms:
     groups:
       - testohpc_compute
       - initial
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -34,7 +34,7 @@ platforms:
     groups:
       - testohpc_compute
       - initial
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     pre_build_image: true
     groups: # NB this is NOT in the "testohpc_compute" so that it isn't added to slurm.conf initially
       - new
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test11/molecule.yml
+++ b/molecule/test11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -21,7 +21,7 @@ platforms:
       - testohpc_compute
       - testohpc_compute_orig
       - testohpc_compute_new
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -34,7 +34,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_compute_orig
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test12/molecule.yml
+++ b/molecule/test12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test13/molecule.yml
+++ b/molecule/test13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_control
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -20,7 +20,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -33,7 +33,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -58,7 +58,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test14/molecule.yml
+++ b/molecule/test14/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test1b/molecule.yml
+++ b/molecule/test1b/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -21,7 +21,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test1c/molecule.yml
+++ b/molecule/test1c/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test2/molecule.yml
+++ b/molecule/test2/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -20,7 +20,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_part1
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -33,7 +33,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_part1
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_part2
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -59,7 +59,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_part2
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test3/molecule.yml
+++ b/molecule/test3/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -20,7 +20,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_grp1
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -33,7 +33,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_grp1
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_grp2
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -59,7 +59,7 @@ platforms:
     groups:
       - testohpc_compute
       - testohpc_grp2
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test4/molecule.yml
+++ b/molecule/test4/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test5/molecule.yml
+++ b/molecule/test5/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -19,7 +19,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -31,7 +31,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test6/molecule.yml
+++ b/molecule/test6/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test7/molecule.yml
+++ b/molecule/test7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test8/molecule.yml
+++ b/molecule/test8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_control
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -20,7 +20,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -33,7 +33,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -58,7 +58,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp

--- a/molecule/test9/molecule.yml
+++ b/molecule/test9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_control
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -20,7 +20,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -33,7 +33,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_login
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -46,7 +46,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp
@@ -58,7 +58,7 @@ platforms:
     pre_build_image: true
     groups:
       - testohpc_compute
-    command: "/bin/bash -c 'dnf -y install systemd && /sbin/init'" # not in RL9 image
+    command: /sbin/init
     tmpfs:
       - /run
       - /tmp


### PR DESCRIPTION
Upstream rockylinux:9.3 images don't contain systemd, which means running `/sbin/init` for molecule fails.

Previously the workaround was to use "/bin/bash -c 'dnf -y install systemd && /sbin/init'" as the container command but this was very flaky. Instead CI now builds an image containing systemd using the upstream rockylinux:9.3 image. This ensures that the image used for the molecule workflow is always updated.