### PR TITLE
Update SelectType from legacy cons_res to current default cons_tres

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -90,7 +90,7 @@ Waittime=0
 #MaxMemPerCPU=0
 #SchedulerTimeSlice=30
 SchedulerType=sched/backfill
-SelectType=select/cons_res
+SelectType=select/cons_tres
 SelectTypeParameters=CR_Core
 #
 #


### PR DESCRIPTION
See https://slurm.schedmd.com/archive/slurm-23.11.4/slurm.conf.html, note current OpenHPC Slurm versions are RL8/OHPCv2.8 = v23.11.4, RL9/OHPCv3.1 = v23.11.6.

