### PR TITLE
Ensure /etc isn't writable by group

### DIFF
--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -41,6 +41,14 @@
   delegate_to: "{{ openhpc_slurm_control_host }}"
   when: openhpc_slurm_control_host in ansible_play_hosts
 
+- name: Fix permissions on /etc to pass Munge startup checks
+  # Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2 makes /etc g=rwx rather than g=rx (where group=root)
+  # which fails munged startup checks
+  file:
+    path: /etc
+    state: directory
+    mode: g-w
+
 - name: Write Munge key
   copy:
     content: "{{ openhpc_munge_key or (openhpc_control_munge_key.content | b64decode) }}"


### PR DESCRIPTION
munged checks on startup that the path to its key is secure. 

Because `Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2` changed the permissions on `/etc` this image fails with:
```
munged: Error: Keyfile is insecure: group-writable permissions without sticky bit set on "/etc"
```

Permissions comparison:
```
# Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2
[rocky@sb-rl9-3 ~]$ ls -ld /etc/
drwxr-xr-x. 93 root root 8192 Jun  5 14:54 /etc/

# Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2
[rocky@sb-rl9-4 ~]$ ls -ld /etc/
drwxrwxr-x. 88 root root 8192 Jun  5 14:54 /etc/
```