### PR TITLE
Retry slurmd restarts on change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -58,6 +58,10 @@
   service:
     name: "slurmd"
     state: restarted
+  retries: 5
+  register: slurmd_restart
+  until: slurmd_restart is success
+  delay: 30
   when:
     - openhpc_slurm_service_started | bool
     - openhpc_enable.batch | default(false) | bool


### PR DESCRIPTION
There was a race conditions between slurmctld starting up and slurmd. This adds a few retries to make it more robust.