### PR TITLE
Fix ReturnToService slurm.conf templating

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -184,4 +184,5 @@ PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ 
 NodeName=nonesuch
 
 {% if openhpc_slurm_configless %}SlurmctldParameters=enable_configless{% endif %}
+
 ReturnToService=2


### PR DESCRIPTION
The ReturnToService parameter is not rendered. A newline between that and the jinja conditional above fixes it