### PR TITLE
Fix slurm.conf jinja templating

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -11,8 +11,6 @@
 ClusterName={{ openhpc_cluster_name }}
 SlurmctldHost={{ openhpc_slurm_control_host }}{% if openhpc_slurm_control_host_address is defined %}({{ openhpc_slurm_control_host_address }}){% endif %}
 
-#SlurmctldHost=
-#
 #DisableRootJobs=NO
 #EnforcePartLimits=NO
 #EpilogSlurmctld=

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -10,6 +10,7 @@
 #
 ClusterName={{ openhpc_cluster_name }}
 SlurmctldHost={{ openhpc_slurm_control_host }}{% if openhpc_slurm_control_host_address is defined %}({{ openhpc_slurm_control_host_address }}){% endif %}
+
 #SlurmctldHost=
 #
 #DisableRootJobs=NO
@@ -186,4 +187,5 @@ PartitionName={{part.name}} Default={{ part.get('default', 'YES') }} MaxTime={{ 
 NodeName=nonesuch
 
 {% if openhpc_slurm_configless %}SlurmctldParameters=enable_configless{% endif %}
+
 ReturnToService=2


### PR DESCRIPTION
trim_blocks on by default in Ansible so extra newline required at end of template tag

https://github.com/stackhpc/ansible-role-openhpc/issues/170#issuecomment-2820986949