### PR TITLE
Relax gres configuration validation to allow multiple conf keys

### DIFF
--- a/files/nodegroup.schema
+++ b/files/nodegroup.schema
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "definitions": {
+    "gres": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "conf": {
+            "type": "string",
+            "minLength": 1
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "conf"
+        ]
+      }
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "gres_autodetect": {
+      "type": "string",
+      "minLength": 1
+    },
+    "gres": {
+      "$ref": "#/definitions/gres"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "if": {
+    "properties": {
+      "gres_autodetect": {
+        "const": "off"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "gres": {
+        "items": {
+          "required": [
+            "file"
+          ]
+        }
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "gres": {
+        "items": {
+          "not": {
+            "required": [
+              "file"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/files/nodegroup.schema
+++ b/files/nodegroup.schema
@@ -1,5 +1,4 @@
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+{  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "definitions": {
     "gres": {
@@ -27,6 +26,21 @@
       "type": "string",
       "minLength": 1
     },
+    "ram_mb": {
+      "type": "number",
+    },
+    "ram_multiplier": {
+      "type": "number",
+    },
+    "features": {
+    	"type": "array",
+        "items": {
+        	"type": "string"
+        }
+    },
+    "node_params": {
+    	"type": "object",
+    },            
     "gres_autodetect": {
       "type": "string",
       "minLength": 1
@@ -38,6 +52,7 @@
   "required": [
     "name"
   ],
+  "additionalProperties": false,
   "if": {
     "properties": {
       "gres_autodetect": {

--- a/files/nodegroup.schema
+++ b/files/nodegroup.schema
@@ -52,7 +52,6 @@
   "required": [
     "name"
   ],
-  "additionalProperties": false,
   "if": {
     "properties": {
       "gres_autodetect": {

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -21,23 +21,15 @@
   delegate_to: localhost
   run_once: true
 
-- name: Check gres configuration when gres_autodetect is set
-  assert:
-    that:
-      - _failure_reasons | selectattr('when', 'truthy') | length == 0
-    fail_msg: >
-      Your nodegroup definition must include a single gres dictionary containing a conf key
-      if gres_autodetect is set. The following nodegroup failed this check: {{ item }}.
-      Reasons for failure: {{ _failure_reasons | selectattr('when', 'truthy') | map(attribute='msg') | join(', ') }}
+- name: Validate openhpc_nodegroups
+  ansible.utils.validate:
+    criteria: "{{ lookup('file', 'nodegroup.schema') }}"
+    engine: 'ansible.utils.jsonschema'
+    data: "{{ item }}"
   vars:
-    _openhpc_gres_autodetect_groups: "{{ openhpc_nodegroups | selectattr('gres_autodetect', 'defined') | selectattr('gres_autodetect', 'search', '(?!off).*') }}"
-    _failure_reasons:
-      - msg: The gres key was a list with more than one item
-        when: "{{ item.gres | length != 1 }}"
-      - msg: The gres dictionary does not contain a conf key
-        when: "{{ item.gres.0.conf is not defined }}"
+    ansible_jsonschema_draft: '2020-12'
   delegate_to: localhost
-  loop: "{{ _openhpc_gres_autodetect_groups }}"
+  loop: "{{ openhpc_nodegroups }}"
   run_once: true
 
 - name: Fail if configuration is old


### PR DESCRIPTION
Validation was too strict and did not allow multiple dictionaries in the gres definition. E.g:

```
  - name: gpu
    gres_autodetect: nvml
    gres:
      - conf: gpu:A100:2
      - conf: gpu:H100:2
```

Was forbidden (for no apparent reason).