### PR TITLE
CI: Limit job parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     needs: build
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         image:
           - 'rockylinux:8.9'


### PR DESCRIPTION
We are seeing random CI failures with:

    Failed to set execute bit on remote files

Limit parallelism in case it is related to concurrent access to the same Docker image.