### PR TITLE
CI: Switch to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     # as the container command is flaky.
     # This job builds an image using the upstream rockylinux:9.3 image which ensures
     # that the image used for the molecule workflow is always updated.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: molecule/images
@@ -36,7 +36,7 @@ jobs:
     
   molecule:
     name: Molecule
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
@@ -108,7 +108,7 @@ jobs:
 
   checks:
     name: Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v3


### PR DESCRIPTION
This appears to resolve issues seen when running concurrent molecule jobs inside containers.