### PR TITLE
CI: Switch to latest rockylinux/rockylinux images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ name: CI
 
 jobs:
   build:
-    name: Build Rocky9 container image
-    # Upstream rockylinux:9.3 images don't contain systemd, which means /sbin/init fails.
+    name: Build Rocky Linux 9 container image
+    # Upstream rockylinux/rockylinux:9 images don't contain systemd, which means /sbin/init fails.
     # A workaround of using "/bin/bash -c 'dnf -y install systemd && /sbin/init'"
     # as the container command is flaky.
-    # This job builds an image using the upstream rockylinux:9.3 image which ensures
+    # This job builds an image using the upstream rockylinux/rockylinux:9 image which ensures
     # that the image used for the molecule workflow is always updated.
     runs-on: ubuntu-latest
     defaults:
@@ -23,16 +23,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build image
-        run: podman build -t rocky93systemd:latest .
+        run: podman build -t rocky9systemd:latest .
 
       - name: Save image
-        run: podman save --output rocky93systemd.docker rocky93systemd:latest
+        run: podman save --output rocky9systemd.docker rocky9systemd:latest
 
       - name: Upload rocky9 image
         uses: actions/upload-artifact@v4
         with:
-          name: rocky93systemd
-          path: molecule/images/rocky93systemd.docker
+          name: rocky9systemd
+          path: molecule/images/rocky9systemd.docker
     
   molecule:
     name: Molecule
@@ -42,8 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - 'rockylinux:8.9'
-          - 'localhost/rocky93systemd'
+          - 'rockylinux/rockylinux:8'
+          - 'localhost/rocky9systemd'
         scenario:
           - test1
           - test1b
@@ -61,7 +61,7 @@ jobs:
         exclude:
           # mariadb package provides /usr/bin/mysql on RL8 which doesn't work with geerlingguy/mysql role
           - scenario: test4
-            image: 'rockylinux:8.9'
+            image: 'rockylinux/rockylinux:8'
 
     steps:
       - name: Check out the codebase.
@@ -70,14 +70,14 @@ jobs:
       - name: Download rocky9 container image
         uses: actions/download-artifact@v4
         with:
-          name: rocky93systemd
-          path: molecule/images/rocky93systemd.docker
-        if: matrix.image == 'localhost/rocky93systemd'
+          name: rocky9systemd
+          path: molecule/images/rocky9systemd.docker
+        if: matrix.image == 'localhost/rocky9systemd'
 
       - name: Load rocky9 container image
-        run: podman load --input rocky93systemd.docker/rocky93systemd.docker
+        run: podman load --input rocky9systemd.docker/rocky9systemd.docker
         working-directory: molecule/images
-        if: matrix.image == 'localhost/rocky93systemd'
+        if: matrix.image == 'localhost/rocky9systemd'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs packages and performs configuration to provide a Slur
 
 As a role it must be used from a playbook, for which a simple example is given below. This approach means it is totally modular with no assumptions about available networks or any cluster features except for some hostname conventions. Any desired cluster fileystem or other required functionality may be freely integrated using additional Ansible roles or other approaches.
 
-The minimal image for nodes is a RockyLinux 8 GenericCloud image.
+The minimal image for nodes is a Rocky Linux 8 GenericCloud image.
 
 ## Task files
 This role provides four task files which can be selected by using the `tasks_from` parameter of Ansible's `import_role` or `include_role` modules:

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -26,7 +26,7 @@ test15 | 1            | Y                       | As for #1 but also tests parti
 
 # Local Installation & Running
 
-Local installation on a RockyLinux 8.x machine looks like:
+Local installation on a Rocky Linux 8.x machine looks like:
 
     sudo dnf install -y podman
     sudo dnf install podman-plugins # required for DNS
@@ -39,17 +39,17 @@ Local installation on a RockyLinux 8.x machine looks like:
     pip install -r molecule/requirements.txt
     ansible-galaxy collection install containers.podman:>=1.10.1
 
-Build a RockyLinux 9.3 image with systemd included:
+Build a Rocky Linux 9 image with systemd included:
 
     cd ansible-role-openhpc/molecule/images
-    podman build -t rocky93systemd:latest .
+    podman build -t rocky9systemd:latest .
 
 Run tests, e.g.:
 
     cd ansible-role-openhpc/
-    MOLECULE_NO_LOG="false" MOLECULE_IMAGE=rockylinux:8.9 molecule test --all
+    MOLECULE_NO_LOG="false" MOLECULE_IMAGE=rockylinux:8 molecule test --all
 
-where the image may be `rockylinux:8.9` or `localhost/rocky93systemd`.
+where the image may be `rockylinux:8` or `localhost/rocky9systemd`.
 
 Other useful options during development:
 - Prevent destroying instances by using `molecule test --destroy never`

--- a/molecule/images/Dockerfile
+++ b/molecule/images/Dockerfile
@@ -1,2 +1,2 @@
-FROM rockylinux:9.3
+FROM rockylinux/rockylinux:9
 RUN dnf install -y systemd && dnf clean all

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -103,6 +103,12 @@
   register: ohpc_cgroup_conf
   # NB uses restart rather than reload as this is needed in some cases
 
+# Workaround for https://bugs.rockylinux.org/view.php?id=10165
+- name: Fix permissions on /etc for Munge service
+  ansible.builtin.file:
+    mode: g-w
+    path: /etc
+
 - name: Ensure Munge service is running
   service:
     name: munge


### PR DESCRIPTION
The curated official images for Rocky Linux are not updated [1]. Use images from the Rocky Linux Docker Hub repository instead [2] with the latest 8 and 9 tags.

[1] https://hub.docker.com/_/rockylinux
[2] https://hub.docker.com/r/rockylinux/rockylinux