### PR TITLE
Change slurmctld and slurmd spool defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ that this is *not the same* as the Ansible `omit` [special variable](https://doc
 
 `openhpc_state_save_location`: Optional. Absolute path for Slurm controller state (`slurm.conf` parameter [StateSaveLocation](https://slurm.schedmd.com/slurm.conf.html#OPT_StateSaveLocation))
 
-`openhpc_slurmd_spool_dir`: Optional. Absolute path for slurmd state (`slurm.conf` parameter [SlurmdSpoolDir](https://slurm.schedmd.com/slurm.conf.html#OPT_SlurmdSpoolDir))
-
 `openhpc_slurm_conf_template`: Optional. Path of Jinja template for `slurm.conf` configuration file. Default is `slurm.conf.j2` template in role. **NB:** The required templating is complex, if just setting specific parameters use `openhpc_config` intead.
 
 `openhpc_slurm_conf_path`: Optional. Path to template `slurm.conf` configuration file to. Default `/etc/slurm/slurm.conf`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ openhpc_cgroup_template: cgroup.conf.j2
 openhpc_mpi_template: mpi.conf.j2
 openhpc_mpi_config: {}
 
-openhpc_state_save_location: /var/spool/slurm
+openhpc_state_save_location: /var/spool/slurmctld
 openhpc_slurmd_spool_dir: /var/spool/slurm
 openhpc_slurm_conf_path: /etc/slurm/slurm.conf
 openhpc_slurm_conf_template: slurm.conf.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,6 @@ openhpc_default_config:
   SlurmctldHost: "{{ openhpc_slurm_control_host }}{% if openhpc_slurm_control_host_address is defined %}({{ openhpc_slurm_control_host_address }}){% endif %}"
   ProctrackType: proctrack/cgroup
   TaskPlugin: task/cgroup,task/affinity
-  SlurmdSpoolDir: /var/spool/slurm # NB: not OpenHPC default!
   SlurmUser: slurm
   StateSaveLocation: "{{ openhpc_state_save_location }}"
   SlurmctldTimeout: 300
@@ -68,7 +67,6 @@ openhpc_mpi_template: mpi.conf.j2
 openhpc_mpi_config: {}
 
 openhpc_state_save_location: /var/spool/slurmctld
-openhpc_slurmd_spool_dir: /var/spool/slurm
 openhpc_slurm_conf_path: /etc/slurm/slurm.conf
 openhpc_slurm_conf_template: slurm.conf.j2
 

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -21,7 +21,7 @@
       enable: control
     - path: "{{ openhpc_slurm_conf_path | dirname }}"
       enable: control
-    - path: "{{ openhpc_slurmd_spool_dir }}" # SlurmdSpoolDir
+    - path: "/var/spool/slurmd" # SLURM's default for SlurmdSpoolDir
       enable: batch
   when: "openhpc_enable[item.enable] | default(false) | bool"
 

--- a/tasks/runtime.yml
+++ b/tasks/runtime.yml
@@ -21,7 +21,7 @@
       enable: control
     - path: "{{ openhpc_slurm_conf_path | dirname }}"
       enable: control
-    - path: "/var/spool/slurmd" # SLURM's default for SlurmdSpoolDir
+    - path: "{{ openhpc_merged_config.SlurmdSpoolDir | default('/var/spool/slurmd') }}"
       enable: batch
   when: "openhpc_enable[item.enable] | default(false) | bool"
 

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -1,7 +1,7 @@
 ClusterName={{ openhpc_cluster_name }}
 
 # PARAMETERS
-{% for k, v in openhpc_default_config | combine(openhpc_config) | items %}
+{% for k, v in openhpc_merged_config | items %}
 {%  if v != "omit" %}{# allow removing items using setting key: omit #}
 {%    if k != 'SlurmctldParameters' %}{# handled separately due to configless mode #}
 {{ k }}={{ v | join(',') if (v is sequence and v is not string) else v }}
@@ -9,7 +9,7 @@ ClusterName={{ openhpc_cluster_name }}
 {%  endif %}
 {% endfor %}
 
-{% set slurmctldparameters = ((openhpc_config.get('SlurmctldParameters', []) + ['enable_configless']) | unique) %}
+{% set slurmctldparameters = ((openhpc_merged_config.get('SlurmctldParameters', []) + ['enable_configless']) | unique) %}
 SlurmctldParameters={{ slurmctldparameters | join(',') }}
 
 # LOGIN-ONLY NODES

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,4 +17,6 @@ ohpc_slurm_packages:
     - "{{ 'lmod-ohpc' if openhpc_module_system_install else '' }}"
   database:
     - "slurm-slurmdbd-ohpc"
+
+openhpc_merged_config: "{{ openhpc_default_config | combine(openhpc_config) }}"
 ...


### PR DESCRIPTION
- StateSaveLocation (slurmctld): change  default to `/var/spool/slurmctld`
  this has no impact on existing deployments because it was already defined in ansible-slurm-appliance
- SlurmdSpoolDir (slurmd): remove default, hardcoded one in slurm is `/var/spool/slurmd`
  (note the extra d)
  this has an impact but as it reside on the root disk, it will disappear on upgrades
