### PR TITLE
SelectTypeParameters=CR_Core_Memory; DefMemPerCPU

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ openhpc_default_config:
   SlurmctldTimeout: 300
   SchedulerType: sched/backfill
   SelectType: select/cons_tres
-  SelectTypeParameters: CR_Core
+  SelectTypeParameters: CR_Core_Memory
   PriorityWeightPartition: 1000
   PreemptType: preempt/partition_prio
   PreemptMode: SUSPEND,GANG
@@ -43,6 +43,7 @@ openhpc_default_config:
   Epilog: /etc/slurm/slurm.epilog.clean
   ReturnToService: 2
   GresTypes: "{{ ohpc_gres_types if ohpc_gres_types != '' else 'omit' }}"
+  DefMemPerCPU: "{{ ohpc_nodegroups_computed.values() | map(attribute='def_mem_per_cpu') | default([100], true) | min }}"
 openhpc_cgroup_default_config:
   ConstrainCores: "yes"
   ConstrainDevices: "yes"

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -22,18 +22,16 @@ NodeName={{ node }}
 # COMPUTE NODES
 {% for nodegroup in openhpc_nodegroups %}
 # nodegroup: {{ nodegroup.name }}
-{%  set inventory_group_name = openhpc_cluster_name ~ '_' ~ nodegroup.name %}
-{%  set inventory_group_hosts = groups.get(inventory_group_name, []) %}
-{%      if inventory_group_hosts | length > 0 %}
-{%          set play_group_hosts = inventory_group_hosts | intersect (play_hosts) %}
-{%          set first_host = play_group_hosts | first | mandatory('Inventory group "' ~ inventory_group_name ~ '" contains no hosts in this play - was --limit used?') %}
-{%          set first_host_hv = hostvars[first_host] %}
-{%          set ram_mb = (first_host_hv['ansible_memory_mb']['real']['total'] * (nodegroup.ram_multiplier | default(openhpc_ram_multiplier))) | int %}
-{%          set hostlists = (inventory_group_hosts | hostlist_expression) %}{# hosts in inventory group aren't necessarily a single hostlist expression #}
+{%  set nodegroup_computed = ohpc_nodegroups_computed.get(nodegroup.name) %}
+{#  see vars/main.yml: if nodegroup_computed, nodegroup has at least 1 host in the inventory #}
+{%  if nodegroup_computed %}
+{%    set inventory_group_hosts = groups[nodegroup_computed.inventory_group_name] %}
+{%    set first_host_hv = hostvars[nodegroup_computed.first_host] %}
+{%    set hostlists = (inventory_group_hosts | hostlist_expression) %}{# hosts in inventory group aren't necessarily a single hostlist expression #}
 NodeName={{ hostlists | join(',') }} {{ '' -}}
     Features={{ (['nodegroup_' ~ nodegroup.name] + nodegroup.features | default([]) ) | join(',') }} {{ '' -}}
     State=UNKNOWN {{ '' -}}
-    RealMemory={{ nodegroup.ram_mb | default(ram_mb) }} {{ '' -}}
+    RealMemory={{ nodegroup.ram_mb | default(nodegroup_computed.ram_mb) }} {{ '' -}}
     Sockets={{ first_host_hv['ansible_processor_count'] }} {{ '' -}}
     CoresPerSocket={{ first_host_hv['ansible_processor_cores'] }} {{ '' -}}
     ThreadsPerCore={{ first_host_hv['ansible_processor_threads_per_core'] }} {{ '' -}}
@@ -44,7 +42,7 @@ NodeName={{ hostlists | join(',') }} {{ '' -}}
     Gres={{ first_host_hv['ohpc_node_gpu_gres'] -}}
     {% endif %}
 
-{%      endif %}{# 1 or more hosts in inventory #}
+{%  endif %}{# 1 or more hosts in inventory #}
 NodeSet=nodegroup_{{ nodegroup.name }} Feature=nodegroup_{{ nodegroup.name }}
 
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,4 +19,25 @@ ohpc_slurm_packages:
     - "slurm-slurmdbd-ohpc"
 
 openhpc_merged_config: "{{ openhpc_default_config | combine(openhpc_config) }}"
+
+ohpc_nodegroups_computed: >
+  {
+  {% for nodegroup in openhpc_nodegroups %}
+  {%  set inventory_group_name = openhpc_cluster_name ~ '_' ~ nodegroup.name %}
+  {%  set inventory_group_hosts = groups.get(inventory_group_name, []) %}
+  {%      if inventory_group_hosts | length > 0 %}
+  {%          set play_group_hosts = inventory_group_hosts | intersect (play_hosts) %}
+  {%          set first_host = play_group_hosts | first | mandatory('Inventory group "' ~ inventory_group_name ~ '" contains no hosts in this play - was --limit used?') %}
+  {%          set first_host_hv = hostvars[first_host] %}
+  {%          set ram_mb = (first_host_hv['ansible_memory_mb']['real']['total'] * (nodegroup.ram_multiplier | default(openhpc_ram_multiplier))) | int %}
+      {{ nodegroup.name | to_json }}: {
+          "inventory_group_name": {{ inventory_group_name | to_json }},
+          "first_host": {{ first_host | to_json }},
+          "ram_mb": {{ ram_mb }},
+          "def_mem_per_cpu": {{ (ram_mb / first_host_hv['ansible_processor_vcpus']) | int }},
+      },
+  {%      endif %}
+  {% endfor %}
+  }
+
 ...


### PR DESCRIPTION
Changes how memory is assessed when scheduling and constrained for a job:

1. The default for the slurm.conf parameter `SelectTypeParameters` is changed from `CR_Core` to `CR_Core_Memory`. Memory is now considered as a consumable resource and a job will be scheduled to a node only if the node has sufficent remaining memory for it. Previously memory was not taken into account when scheduling.

2. Although the default cgroup configuration is not changed, the change to `SelectTypeParameters` means a job’s memory and swap use are now constrained to the requested values.

3. The default memory request for a job is set, per allocated CPU, by the slurm.conf parameter `DefMemPerCPU`. This is set here to the minimum memory per thread for any node across the cluster.

---

To provide computed per-nodegroup values in multiple places this adds an internal variable `ohpc_nodegroups_computed`. If a nodegroup is in this mapping it has at least one host. It stores:
- `first_host`: The inventory name of the first host in the nodegroup; use `hostvars[computed.first_host]`
to access its hostvars.
- `inventory_group_name`: The name of the inventory group for this nodegroup; use `groups[computed.inventory_group_name]` to access the host list.
