### PR TITLE
EnforcePartLimits=ANY default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ openhpc_default_config:
   SlurmctldSyslogDebug: info
   SlurmdSyslogDebug: info
   PropagateResourceLimitsExcept: MEMLOCK
+  EnforcePartLimits: ANY
   Epilog: /etc/slurm/slurm.epilog.clean
   ReturnToService: 2
   GresTypes: "{{ ohpc_gres_types if ohpc_gres_types != '' else 'omit' }}"


### PR DESCRIPTION
This will outright reject jobs that requests more nodes or more than MaxMemPerCPU, MaxMemPerNode, MinNodes, MaxNodes, MaxTime, AllocNodes, AllowAccounts, AllowGroups, AllowQOS, and QOS usage than is available in any of the requested partitions.

If submitting to multiple partitions and one partitions fits, it will be used (contrary to EnforcePartLimits=ALL).